### PR TITLE
Emit UNKNOWN_EVENT_TYPE in default LoadAttachment worker.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@devrev/ts-adaas",
-  "version": "1.2.0-beta",
+  "version": "1.2.0-beta.1",
   "description": "DevRev ADaaS (AirDrop-as-a-Service) Typescript SDK.",
   "type": "commonjs",
   "main": "./dist/index.js",

--- a/src/workers/default-workers/load-attachments.ts
+++ b/src/workers/default-workers/load-attachments.ts
@@ -1,11 +1,12 @@
-import { processTask } from 'workers/process-task';
-import { LoaderEventType } from 'types';
+import { processTask } from '../process-task';
+import { LoaderEventType } from '../../types';
 
 processTask({
   task: async ({ adapter }) => {
-    await adapter.emit(LoaderEventType.AttachmentLoadingDone, {
-      reports: adapter.reports,
-      processed_files: adapter.processedFiles,
+    await adapter.emit(LoaderEventType.UnknownEventType, {
+      error: {
+        message: 'Event type ' + adapter.event.payload.event_type + ' not supported.'
+       }
     });
   },
   onTimeout: async ({ adapter }) => {

--- a/src/workers/default-workers/load-data.ts
+++ b/src/workers/default-workers/load-data.ts
@@ -1,4 +1,4 @@
-import { processTask } from 'workers/process-task';
+import { processTask } from '../process-task';
 import { LoaderEventType } from '../../types/loading';
 
 processTask({


### PR DESCRIPTION
Emit UKNOWN_EVENT_TYPE if no worker is provided in the ADaaS connector.