### PR TITLE
Sleep if timeout is hit during default attachments processing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@devrev/ts-adaas",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@devrev/ts-adaas",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "license": "ISC",
       "dependencies": {
         "@devrev/typescript-sdk": "^1.1.59",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@devrev/ts-adaas",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Typescript library containing the ADaaS(AirDrop as a Service) control protocol.",
   "type": "commonjs",
   "main": "./dist/index.js",

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -43,3 +43,5 @@ export const AIRDROP_DEFAULT_ITEM_TYPES = {
 };
 
 export const LIBRARY_VERSION = getLibraryVersion();
+
+export const DEFAULT_SLEEP_DELAY_MS = 180000; // 3 minutes

--- a/src/common/helpers.ts
+++ b/src/common/helpers.ts
@@ -194,3 +194,8 @@ export function getLibraryVersion() {
     return '';
   }
 }
+
+export function sleep(ms: number) {
+  console.log(`Sleeping for ${ms}ms.`);
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/src/workers/worker-adapter.ts
+++ b/src/workers/worker-adapter.ts
@@ -25,6 +25,7 @@ import {
   AIRDROP_DEFAULT_ITEM_TYPES,
   ALLOWED_EXTRACTION_EVENT_TYPES,
   STATELESS_EVENT_TYPES,
+  DEFAULT_SLEEP_DELAY_MS,
 } from '../common/constants';
 import { State } from '../state/state';
 import { WorkerAdapterInterface, WorkerAdapterOptions } from '../types/workers';
@@ -46,6 +47,7 @@ import { Mappers } from '../mappers/mappers';
 import { Uploader } from '../uploader/uploader';
 import { serializeAxiosError } from '../logger/logger';
 import { SyncMapperRecordStatus } from '../mappers/mappers.interface';
+import { sleep } from '../common/helpers';
 
 export function createWorkerAdapter<ConnectorState>({
   event,
@@ -877,6 +879,12 @@ export class WorkerAdapter<ConnectorState> {
 
     // Loop through the batches of attachments
     for (let i = lastProcessedBatchIndex; i < reducedAttachments.length; i++) {
+
+      // Check if we hit timeout 
+      if (adapter.isTimeout) {
+        await sleep(DEFAULT_SLEEP_DELAY_MS);
+      }
+      
       const attachmentsBatch = reducedAttachments[i];
 
       // Create a list of promises for parallel processing


### PR DESCRIPTION
## Summary
This pull request introduces a minor version update to the library and adds a new utility for handling timeouts, which is integrated into the `WorkerAdapter` class. This mitigates the issue of lambda timing out. The most important changes include the addition of a `sleep` function and a default sleep delay constant, as well as their usage in the `WorkerAdapter` to handle timeouts.

## Related Issues
- work-item: https://app.devrev.ai/devrev/works/ISS-179204

## Type of Change
- [x] Change doesn't affect products or customers
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Non-breaking change (the new functionality and code refactor do not require a migration strategy)
- [ ] Breaking change (fix or feature that will require a migration plan for data or other services)
- [ ] Documentation/comment update
- [ ] Other (please describe):

## Testing Procedure
- Run any ADaaS snap-in where you experience problems with lambda timeout-ing during attachments extraction, using this library version: 1.5.1

## Checklist
- [x] I used generative AI to generate this PR
- [x] I have self-reviewed my code for clarity and correctness
- [ ] I have added or updated comments for complex or non-obvious logic in my code
- [ ] I have updated relevant documentation (e.g., README, code docs)
- [x] My changes do not introduce new warnings or errors
- [ ] I have added or updated tests to cover new or changed functionality
- [x] All tests pass locally with my changes applied
