### PR TITLE
Add reset_extract_from field to EventContext type

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -259,7 +259,7 @@ Defines the structure of the event context that is sent to the external connecto
 
   Required. A **string** representing the request ID.
 
-- _reset_extraction_
+- _reset_extract_from_
 
   Optional. A **boolean** signifying the incremental sync should start from the given `extract_from` timestamp if true or from `lastSuccessfulSyncStarted` timestamp if false.
 

--- a/src/types/extraction.test.ts
+++ b/src/types/extraction.test.ts
@@ -17,7 +17,7 @@ describe('EventContext type tests', () => {
         ...baseEvent.payload.event_context,
         extract_from: '2024-01-01T00:00:00Z',
         initial_sync_scope: InitialSyncScope.TIME_SCOPED,
-        reset_extraction: true
+        reset_extract_from: true
     } as EventContext;
 
     // Test with all optionals present

--- a/src/types/extraction.ts
+++ b/src/types/extraction.ts
@@ -157,7 +157,11 @@ export interface EventContext {
   initial_sync_scope?: InitialSyncScope;
   mode: string;
   request_id: string;
+  /**
+   * @deprecated reset_extraction is deprecated and should not be used. Use reset_extract_from instead.
+   */
   reset_extraction?: boolean;
+  reset_extract_from?: boolean;
   snap_in_slug: string;
   snap_in_version_id: string;
   sync_run: string;


### PR DESCRIPTION
## Summary
This pull request updates the `EventContext` type to replace the deprecated `reset_extraction` property with a new `reset_extract_from` property.

* [`src/types/extraction.ts`](diffhunk://#diff-0d46a13ab414211ae3ae62069ab2b48732ab5f1a7d767932722f387b73353333R160-R164): Added a new property `reset_extract_from` and marked `reset_extraction` as deprecated.
* [`src/types/extraction.test.ts`](diffhunk://#diff-837890b2b60eebb61975b2620ee415f06f48eabce29362336d7d6a11687659f2L20-R20): Updated test cases to use `reset_extract_from` instead of the deprecated `reset_extraction` property.
* [`REFERENCE.md`](diffhunk://#diff-6269a4217141bc6fd747b87032c8f248c977cfd8b2f0d0d7d1ba04af62ba229aL262-R262): Updated the documentation to reflect the property name change from `reset_extraction` to `reset_extract_from`.

## Connected Issues
- https://app.devrev.ai/devrev/works/ISS-193934
