### PR TITLE
Consider inline field while creating SSOR attachment object

### DIFF
--- a/src/uploader/uploader.interfaces.ts
+++ b/src/uploader/uploader.interfaces.ts
@@ -79,6 +79,7 @@ export interface SsorAttachment {
   actor_id?: {
     external: string;
   };
+  inline?: boolean;
 }
 
 export interface StatsFileResponse {

--- a/src/workers/worker-adapter.ts
+++ b/src/workers/worker-adapter.ts
@@ -740,6 +740,10 @@ export class WorkerAdapter<ConnectorState> {
         };
       }
 
+      if (attachment.inline) {
+        ssorAttachment.inline = true;
+      }
+
       await this.getRepo('ssor_attachment')?.push([ssorAttachment]);
     }
     return;


### PR DESCRIPTION
## Summary
<!-- Provide a brief description of the story behind this PR, as if explaining
     to a non-technical person. Or to an LLM so it can learn from it for
     future (autonomous) code improvements. Feel free to point to a deeper
     design doc, if applicable.
-->
This PR fixes that `inline` field is passed from attachment metadata object to ssor attachment one. Loader needs this while loading inline attachments for articles.

## Connected Issues
<!-- Have you cared to connect this PR to a work item in DevRev, so that we
     can understand future routing and attribution?
-->
- https://app.devrev.ai/devrev/works/ISS-196132
