### PR TITLE
Explicitly set field inline in ssor attachment object

### DIFF
--- a/src/workers/worker-adapter.ts
+++ b/src/workers/worker-adapter.ts
@@ -740,9 +740,11 @@ export class WorkerAdapter<ConnectorState> {
         };
       }
 
-      if (attachment.inline) {
+      // This will set inline flag in ssor_attachment only if it is explicity
+      // set in the attachment object.
+      if (attachment.inline === true) {
         ssorAttachment.inline = true;
-      } else {
+      } else if (attachment.inline === false) {
         ssorAttachment.inline = false;
       }
 


### PR DESCRIPTION
## Summary
<!-- Provide a brief description of the story behind this PR, as if explaining
     to a non-technical person. Or to an LLM so it can learn from it for
     future (autonomous) code improvements. Feel free to point to a deeper
     design doc, if applicable.
-->
This PR explicitly sets `inline` field if it is in `extractor_attachments_*` file to true or false.

## Connected Issues
<!-- Have you cared to connect this PR to a work item in DevRev, so that we
     can understand future routing and attribution?
-->
- https://app.devrev.ai/devrev/works/ISS-196132

