### PR TITLE
Fix the issue, where the worker thread returns multiple emit events instead of one

### DIFF
--- a/src/workers/worker-adapter.ts
+++ b/src/workers/worker-adapter.ts
@@ -208,6 +208,7 @@ export class WorkerAdapter<ConnectorState> {
       } catch (error) {
         console.error('Error while uploading repos', error);
         parentPort?.postMessage(WorkerMessageSubject.WorkerMessageExit);
+        this.hasWorkerEmitted = true;
         return;
       }
     }
@@ -232,6 +233,8 @@ export class WorkerAdapter<ConnectorState> {
       } catch (error) {
         console.error('Error while posting state', error);
         parentPort?.postMessage(WorkerMessageSubject.WorkerMessageExit);
+        this.hasWorkerEmitted = true;
+        return;
       }
     }
 
@@ -254,14 +257,15 @@ export class WorkerAdapter<ConnectorState> {
         payload: { eventType: newEventType },
       };
       this.artifacts = [];
-      this.hasWorkerEmitted = true;
       parentPort?.postMessage(message);
+      this.hasWorkerEmitted = true;
     } catch (error) {
       console.error(
         `Error while emitting event with event type: ${newEventType}.`,
         serializeError(error)
       );
       parentPort?.postMessage(WorkerMessageSubject.WorkerMessageExit);
+      this.hasWorkerEmitted = true;
     }
   }
 


### PR DESCRIPTION
## Summary
<!-- Provide a brief description of the story behind this PR, as if explaining
     to a non-technical person. Or to an LLM so it can learn from it for
     future (autonomous) code improvements. Feel free to point to a deeper
     design doc, if applicable.
-->
There was an issue with the worker thread emitting multiple messages. There were checks to prevent this from happening, but some branches weren't setting the flags required for those.

Usually when the emit function is called, the worker has finished the work. If any of those function calls inside of the emit fail, they should be reported as errors and that should be the only error visible. Currently multiple errors can still be returned and the wanted message at the end.

## Connected Issues
<!-- Have you cared to connect this PR to a work item in DevRev, so that we
     can understand future routing and attribution?
-->
[#ISS-189381](https://app.devrev.ai/devrev/works/ISS-189381)