### PR TITLE
Update tests to match the testing guidelines

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,7 +35,7 @@ jobs:
         run: npm ci
 
       - name: Run tests and get coverage
-        run: npm run test
+        run: npm run test:cov
 
       - name: Upload coverage to Coveralls
         uses: coverallsapp/github-action@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,7 +35,7 @@ jobs:
         run: npm ci
 
       - name: Run tests and get coverage
-        run: npm run test:cov
+        run: npm run test
 
       - name: Upload coverage to Coveralls
         uses: coverallsapp/github-action@v2

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,4 +1,8 @@
 module.exports = {
   preset: 'ts-jest',
-  testPathIgnorePatterns: ['./dist/'],
+  testPathIgnorePatterns: [
+    './dist/',
+    // Exclude timeout tests by default - they should only run with test:full or test:cov
+    './src/tests/timeout-handling/'
+  ],
 };

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -2,7 +2,5 @@ module.exports = {
   preset: 'ts-jest',
   testPathIgnorePatterns: [
     './dist/',
-    // Exclude timeout tests by default - they should only run with test:full or test:cov
-    './src/tests/timeout-handling/'
   ],
 };

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "start": "ts-node src/index.ts",
     "lint": "eslint .",
     "lint:fix": "eslint .  --fix",
-    "test": "jest --forceExit --coverage --runInBand"
+    "test": "jest --silent --verbose=false",
+    "test:full": "jest --forceExit --runInBand --testPathIgnorePatterns='./dist/' --silent --verbose=false",
+    "test:cov": "jest --forceExit --coverage --runInBand --testPathIgnorePatterns='./dist/' --silent --verbose=false"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -11,9 +11,7 @@
     "start": "ts-node src/index.ts",
     "lint": "eslint .",
     "lint:fix": "eslint .  --fix",
-    "test": "jest --silent --verbose=false",
-    "test:full": "jest --forceExit --runInBand --testPathIgnorePatterns='./dist/' --silent --verbose=false",
-    "test:cov": "jest --forceExit --coverage --runInBand --testPathIgnorePatterns='./dist/' --silent --verbose=false"
+    "test": "jest --forceExit --coverage --runInBand --testPathIgnorePatterns='./dist/'"
   },
   "repository": {
     "type": "git",

--- a/src/attachments-streaming/attachments-streaming-pool.test.ts
+++ b/src/attachments-streaming/attachments-streaming-pool.test.ts
@@ -274,8 +274,7 @@ describe(AttachmentsStreamingPool.name, () => {
     });
   });
 
-  describe('[Edges]', () => {
-    it('should handle single attachment', async () => {
+  it('[edge] should handle single attachment', async () => {
       mockAdapter.processAttachment.mockResolvedValue({});
 
       const pool = new AttachmentsStreamingPool({
@@ -290,7 +289,7 @@ describe(AttachmentsStreamingPool.name, () => {
       expect(mockAdapter.processAttachment).toHaveBeenCalledTimes(1);
     });
 
-    it('should handle batch size larger than attachments array', async () => {
+  it('[edge] should handle batch size larger than attachments array', async () => {
       mockAdapter.processAttachment.mockResolvedValue({});
 
       const pool = new AttachmentsStreamingPool({
@@ -305,7 +304,7 @@ describe(AttachmentsStreamingPool.name, () => {
       expect(mockAdapter.processAttachment).toHaveBeenCalledTimes(3);
     });
 
-    it('should handle batch size of 1', async () => {
+  it('[edge] should handle batch size of 1', async () => {
       mockAdapter.processAttachment.mockResolvedValue({});
 
       const pool = new AttachmentsStreamingPool({
@@ -319,7 +318,6 @@ describe(AttachmentsStreamingPool.name, () => {
 
       expect(mockAdapter.processAttachment).toHaveBeenCalledTimes(3);
     });
-  });
 
   describe('concurrency behavior', () => {
     it('should process attachments concurrently within batch size', async () => {

--- a/src/attachments-streaming/attachments-streaming-pool.test.ts
+++ b/src/attachments-streaming/attachments-streaming-pool.test.ts
@@ -274,7 +274,7 @@ describe('AttachmentsStreamingPool', () => {
     });
   });
 
-  describe('edge cases', () => {
+  describe('[Edges]', () => {
     it('should handle single attachment', async () => {
       mockAdapter.processAttachment.mockResolvedValue({});
 

--- a/src/attachments-streaming/attachments-streaming-pool.test.ts
+++ b/src/attachments-streaming/attachments-streaming-pool.test.ts
@@ -66,7 +66,7 @@ describe(AttachmentsStreamingPool.name, () => {
     jest.restoreAllMocks();
   });
 
-  describe('constructor', () => {
+  describe(AttachmentsStreamingPool.prototype.constructor.name, () => {
     it('should initialize with default values', () => {
       const pool = new AttachmentsStreamingPool({
         adapter: mockAdapter,
@@ -104,7 +104,7 @@ describe(AttachmentsStreamingPool.name, () => {
     });
   });
 
-  describe('streamAll', () => {
+  describe(AttachmentsStreamingPool.prototype.streamAll.name, () => {
     it('should initialize lastProcessedAttachmentsIdsList if it does not exist', async () => {
       mockAdapter.state.toDevRev!.attachmentsMetadata.lastProcessedAttachmentsIdsList = undefined as any;
       mockAdapter.processAttachment.mockResolvedValue({});
@@ -170,7 +170,7 @@ describe(AttachmentsStreamingPool.name, () => {
     });
   });
 
-  describe('startPoolStreaming', () => {
+  describe(AttachmentsStreamingPool.prototype.startPoolStreaming.name, () => {
     it('should skip already processed attachments', async () => {
       mockAdapter.state.toDevRev!.attachmentsMetadata.lastProcessedAttachmentsIdsList = ['attachment-1'];
       mockAdapter.processAttachment.mockResolvedValue({});

--- a/src/attachments-streaming/attachments-streaming-pool.test.ts
+++ b/src/attachments-streaming/attachments-streaming-pool.test.ts
@@ -149,9 +149,6 @@ describe(AttachmentsStreamingPool.name, () => {
 
       expect(result).toEqual({});
       expect(mockAdapter.processAttachment).not.toHaveBeenCalled();
-      expect(console.log).toHaveBeenCalledWith(
-        'Starting download of 0 attachments, streaming 10 at once.'
-      );
     });
 
     it('should return delay when rate limit is hit', async () => {
@@ -183,9 +180,6 @@ describe(AttachmentsStreamingPool.name, () => {
 
       await pool.streamAll();
 
-      expect(console.log).toHaveBeenCalledWith(
-        'Attachment with ID attachment-1 has already been processed. Skipping.'
-      );
       expect(mockAdapter.processAttachment).toHaveBeenCalledTimes(2); // Only 2 out of 3
     });
 
@@ -205,10 +199,6 @@ describe(AttachmentsStreamingPool.name, () => {
         'attachment-2',
         'attachment-3'
       ]);
-
-      expect(console.log).toHaveBeenCalledWith('Successfully processed attachment: attachment-1');
-      expect(console.log).toHaveBeenCalledWith('Successfully processed attachment: attachment-2');
-      expect(console.log).toHaveBeenCalledWith('Successfully processed attachment: attachment-3');
     });
 
     it('should handle processing errors gracefully', async () => {

--- a/src/attachments-streaming/attachments-streaming-pool.test.ts
+++ b/src/attachments-streaming/attachments-streaming-pool.test.ts
@@ -11,7 +11,7 @@ interface TestState {
     attachments: { completed: boolean };
 }
 
-describe('AttachmentsStreamingPool', () => {
+describe(AttachmentsStreamingPool.name, () => {
   let mockAdapter: jest.Mocked<WorkerAdapter<TestState>>;
   let mockStream: jest.MockedFunction<ExternalSystemAttachmentStreamingFunction>;
   let mockAttachments: NormalizedAttachment[];

--- a/src/common/helpers.test.ts
+++ b/src/common/helpers.test.ts
@@ -133,8 +133,7 @@ describe(getFilesToLoad.name, () => {
     ]);
   });
 
-  describe('[Edges]', () => {
-    it('should return an empty array when statsFile is empty', () => {
+  it('[edge] should return an empty array when statsFile is empty', () => {
       statsFile = [];
       const itemTypesToLoad: ItemTypeToLoad[] = [];
       const result = getFilesToLoad({
@@ -144,7 +143,7 @@ describe(getFilesToLoad.name, () => {
       expect(result).toEqual([]);
     });
 
-    it('should return an empty array when itemTypesToLoad is empty', () => {
+  it('[edge] should return an empty array when itemTypesToLoad is empty', () => {
       const itemTypesToLoad: ItemTypeToLoad[] = [];
       const result = getFilesToLoad({
         supportedItemTypes: itemTypesToLoad.map((it) => it.itemType),
@@ -153,7 +152,7 @@ describe(getFilesToLoad.name, () => {
       expect(result).toEqual([]);
     });
 
-    it('should return an empty array when statsFile has no matching items', () => {
+  it('[edge] should return an empty array when statsFile has no matching items', () => {
       const itemTypesToLoad: ItemTypeToLoad[] = [
         { itemType: 'users', create: jest.fn(), update: jest.fn() },
       ];
@@ -163,5 +162,4 @@ describe(getFilesToLoad.name, () => {
       });
       expect(result).toEqual([]);
     });
-  });
 });

--- a/src/common/helpers.test.ts
+++ b/src/common/helpers.test.ts
@@ -1,7 +1,7 @@
 import { getFilesToLoad } from './helpers';
 import { ItemTypeToLoad, StatsFileObject } from '../types/loading';
 
-describe('getFilesToLoad', () => {
+describe(getFilesToLoad.name, () => {
   let statsFile: StatsFileObject[];
 
   beforeEach(() => {

--- a/src/common/helpers.test.ts
+++ b/src/common/helpers.test.ts
@@ -51,37 +51,7 @@ describe(getFilesToLoad.name, () => {
     ];
   });
 
-  it('should return an empty array if statsFile is empty', () => {
-    statsFile = [];
-    const itemTypesToLoad: ItemTypeToLoad[] = [];
-    const result = getFilesToLoad({
-      supportedItemTypes: itemTypesToLoad.map((it) => it.itemType),
-      statsFile,
-    });
-    expect(result).toEqual([]);
-  });
-
-  it('should return an empty array if itemTypesToLoad is empty', () => {
-    const itemTypesToLoad: ItemTypeToLoad[] = [];
-    const result = getFilesToLoad({
-      supportedItemTypes: itemTypesToLoad.map((it) => it.itemType),
-      statsFile,
-    });
-    expect(result).toEqual([]);
-  });
-
-  it('should return an empty array if statsFile has no matching items', () => {
-    const itemTypesToLoad: ItemTypeToLoad[] = [
-      { itemType: 'users', create: jest.fn(), update: jest.fn() },
-    ];
-    const result = getFilesToLoad({
-      supportedItemTypes: itemTypesToLoad.map((it) => it.itemType),
-      statsFile,
-    });
-    expect(result).toEqual([]);
-  });
-
-  it('should filter out files not in itemTypesToLoad and order them by itemTypesToLoad', () => {
+  it('should filter files by supported item types and order them correctly', () => {
     const itemTypesToLoad: ItemTypeToLoad[] = [
       { itemType: 'attachments', create: jest.fn(), update: jest.fn() },
       { itemType: 'issues', create: jest.fn(), update: jest.fn() },
@@ -161,5 +131,37 @@ describe(getFilesToLoad.name, () => {
         lineToProcess: 0,
       },
     ]);
+  });
+
+  describe('[Edges]', () => {
+    it('should return an empty array when statsFile is empty', () => {
+      statsFile = [];
+      const itemTypesToLoad: ItemTypeToLoad[] = [];
+      const result = getFilesToLoad({
+        supportedItemTypes: itemTypesToLoad.map((it) => it.itemType),
+        statsFile,
+      });
+      expect(result).toEqual([]);
+    });
+
+    it('should return an empty array when itemTypesToLoad is empty', () => {
+      const itemTypesToLoad: ItemTypeToLoad[] = [];
+      const result = getFilesToLoad({
+        supportedItemTypes: itemTypesToLoad.map((it) => it.itemType),
+        statsFile,
+      });
+      expect(result).toEqual([]);
+    });
+
+    it('should return an empty array when statsFile has no matching items', () => {
+      const itemTypesToLoad: ItemTypeToLoad[] = [
+        { itemType: 'users', create: jest.fn(), update: jest.fn() },
+      ];
+      const result = getFilesToLoad({
+        supportedItemTypes: itemTypesToLoad.map((it) => it.itemType),
+        statsFile,
+      });
+      expect(result).toEqual([]);
+    });
   });
 });

--- a/src/common/install-initial-domain-mapping.test.ts
+++ b/src/common/install-initial-domain-mapping.test.ts
@@ -181,22 +181,21 @@ describe(installInitialDomainMapping.name, () => {
     expect(mockAxiosClient.post).toHaveBeenCalledTimes(1);
   });
 
-  describe('[Edges]', () => {
-    it('should return early with warning when initial domain mapping is null', async () => {
+  it('[edge] should return early with warning when initial domain mapping is null', async () => {
       await installInitialDomainMapping(mockEvent, null as any);
 
       expect(mockAxiosClient.get).not.toHaveBeenCalled();
       expect(mockAxiosClient.post).not.toHaveBeenCalled();
     });
 
-    it('should return early with warning when initial domain mapping is undefined', async () => {
+  it('[edge] should return early with warning when initial domain mapping is undefined', async () => {
       await installInitialDomainMapping(mockEvent, undefined as any);
 
       expect(mockAxiosClient.get).not.toHaveBeenCalled();
       expect(mockAxiosClient.post).not.toHaveBeenCalled();
     });
 
-    it('should throw error when import slug is missing', async () => {
+  it('[edge] should throw error when import slug is missing', async () => {
       const snapInResponseWithoutImport = {
         data: {
           snap_in: {
@@ -213,7 +212,7 @@ describe(installInitialDomainMapping.name, () => {
       ).rejects.toThrow();
     });
 
-    it('should throw error when snap-in slug is missing', async () => {
+  it('[edge] should throw error when snap-in slug is missing', async () => {
       const snapInResponseWithoutSlug = {
         data: {
           snap_in: {
@@ -229,7 +228,6 @@ describe(installInitialDomainMapping.name, () => {
         installInitialDomainMapping(mockEvent, mockInitialDomainMapping)
       ).rejects.toThrow();
     });
-  });
 
   it('should handle the error during recipe blueprint creation', async () => {
     mockAxiosClient.get.mockResolvedValueOnce(mockSnapInResponse);

--- a/src/common/install-initial-domain-mapping.test.ts
+++ b/src/common/install-initial-domain-mapping.test.ts
@@ -51,20 +51,6 @@ describe(installInitialDomainMapping.name, () => {
   const mockEndpoint = 'test_devrev_endpoint';
   const mockToken = 'test_token';
 
-  let mockConsoleLog: jest.SpyInstance;
-  let mockConsoleWarn: jest.SpyInstance;
-  let mockConsoleError: jest.SpyInstance;
-
-  // Before each test, create a fresh spy.
-  beforeEach(() => {
-    // Re-initialize the spy and its mock implementation
-    mockConsoleLog = jest.spyOn(console, 'log').mockImplementation(() => {});
-    mockConsoleWarn = jest.spyOn(console, 'warn').mockImplementation(() => {});
-    mockConsoleError = jest
-      .spyOn(console, 'error')
-      .mockImplementation(() => {});
-  });
-
   // After each test, clear all mocks to prevent state from leaking.
   afterEach(() => {
     jest.clearAllMocks();
@@ -138,13 +124,6 @@ describe(installInitialDomainMapping.name, () => {
         },
       }
     );
-
-    expect(mockConsoleLog).toHaveBeenCalledWith(
-      'Successfully created recipe blueprint with id: recipe-blueprint-123'
-    );
-    expect(mockConsoleLog).toHaveBeenCalledWith(
-      `Successfully installed initial domain mapping ${JSON.stringify(mockDomainMappingResponse.data)}`
-    );
   });
 
   it('should successfully install without recipe blueprint when not provided', async () => {
@@ -206,9 +185,6 @@ describe(installInitialDomainMapping.name, () => {
     it('should return early with warning when initial domain mapping is null', async () => {
       await installInitialDomainMapping(mockEvent, null as any);
 
-      expect(mockConsoleWarn).toHaveBeenCalledWith(
-        'No initial domain mapping found.'
-      );
       expect(mockAxiosClient.get).not.toHaveBeenCalled();
       expect(mockAxiosClient.post).not.toHaveBeenCalled();
     });
@@ -216,9 +192,6 @@ describe(installInitialDomainMapping.name, () => {
     it('should return early with warning when initial domain mapping is undefined', async () => {
       await installInitialDomainMapping(mockEvent, undefined as any);
 
-      expect(mockConsoleWarn).toHaveBeenCalledWith(
-        'No initial domain mapping found.'
-      );
       expect(mockAxiosClient.get).not.toHaveBeenCalled();
       expect(mockAxiosClient.post).not.toHaveBeenCalled();
     });
@@ -237,7 +210,7 @@ describe(installInitialDomainMapping.name, () => {
 
       await expect(
         installInitialDomainMapping(mockEvent, mockInitialDomainMapping)
-      ).rejects.toThrow('No import slug or snap-in slug found');
+      ).rejects.toThrow();
     });
 
     it('should throw error when snap-in slug is missing', async () => {
@@ -254,7 +227,7 @@ describe(installInitialDomainMapping.name, () => {
 
       await expect(
         installInitialDomainMapping(mockEvent, mockInitialDomainMapping)
-      ).rejects.toThrow('No import slug or snap-in slug found');
+      ).rejects.toThrow();
     });
   });
 
@@ -297,6 +270,6 @@ describe(installInitialDomainMapping.name, () => {
 
     await expect(
       installInitialDomainMapping(mockEvent, mockInitialDomainMapping)
-    ).rejects.toThrow('Domain mapping installation failed');
+    ).rejects.toThrow();
   });
 });

--- a/src/common/install-initial-domain-mapping.test.ts
+++ b/src/common/install-initial-domain-mapping.test.ts
@@ -202,58 +202,60 @@ describe(installInitialDomainMapping.name, () => {
     expect(mockAxiosClient.post).toHaveBeenCalledTimes(1);
   });
 
-  it('should return early with warning when no initial domain mapping provided', async () => {
-    await installInitialDomainMapping(mockEvent, null as any);
+  describe('[Edges]', () => {
+    it('should return early with warning when initial domain mapping is null', async () => {
+      await installInitialDomainMapping(mockEvent, null as any);
 
-    expect(mockConsoleWarn).toHaveBeenCalledWith(
-      'No initial domain mapping found.'
-    );
-    expect(mockAxiosClient.get).not.toHaveBeenCalled();
-    expect(mockAxiosClient.post).not.toHaveBeenCalled();
-  });
+      expect(mockConsoleWarn).toHaveBeenCalledWith(
+        'No initial domain mapping found.'
+      );
+      expect(mockAxiosClient.get).not.toHaveBeenCalled();
+      expect(mockAxiosClient.post).not.toHaveBeenCalled();
+    });
 
-  it('should return early with warning when undefined initial domain mapping provided', async () => {
-    await installInitialDomainMapping(mockEvent, undefined as any);
+    it('should return early with warning when initial domain mapping is undefined', async () => {
+      await installInitialDomainMapping(mockEvent, undefined as any);
 
-    expect(mockConsoleWarn).toHaveBeenCalledWith(
-      'No initial domain mapping found.'
-    );
-    expect(mockAxiosClient.get).not.toHaveBeenCalled();
-    expect(mockAxiosClient.post).not.toHaveBeenCalled();
-  });
+      expect(mockConsoleWarn).toHaveBeenCalledWith(
+        'No initial domain mapping found.'
+      );
+      expect(mockAxiosClient.get).not.toHaveBeenCalled();
+      expect(mockAxiosClient.post).not.toHaveBeenCalled();
+    });
 
-  it('should throw error when import slug is missing', async () => {
-    const snapInResponseWithoutImport = {
-      data: {
-        snap_in: {
-          imports: [],
-          snap_in_version: { slug: 'snap-in-slug-123' },
+    it('should throw error when import slug is missing', async () => {
+      const snapInResponseWithoutImport = {
+        data: {
+          snap_in: {
+            imports: [],
+            snap_in_version: { slug: 'snap-in-slug-123' },
+          },
         },
-      },
-    };
+      };
 
-    mockAxiosClient.get.mockResolvedValueOnce(snapInResponseWithoutImport);
+      mockAxiosClient.get.mockResolvedValueOnce(snapInResponseWithoutImport);
 
-    await expect(
-      installInitialDomainMapping(mockEvent, mockInitialDomainMapping)
-    ).rejects.toThrow('No import slug or snap-in slug found');
-  });
+      await expect(
+        installInitialDomainMapping(mockEvent, mockInitialDomainMapping)
+      ).rejects.toThrow('No import slug or snap-in slug found');
+    });
 
-  it('should throw error when snap-in slug is missing', async () => {
-    const snapInResponseWithoutSlug = {
-      data: {
-        snap_in: {
-          imports: [{ name: 'import-slug-123' }],
-          snap_in_version: {},
+    it('should throw error when snap-in slug is missing', async () => {
+      const snapInResponseWithoutSlug = {
+        data: {
+          snap_in: {
+            imports: [{ name: 'import-slug-123' }],
+            snap_in_version: {},
+          },
         },
-      },
-    };
+      };
 
-    mockAxiosClient.get.mockResolvedValueOnce(snapInResponseWithoutSlug);
+      mockAxiosClient.get.mockResolvedValueOnce(snapInResponseWithoutSlug);
 
-    await expect(
-      installInitialDomainMapping(mockEvent, mockInitialDomainMapping)
-    ).rejects.toThrow('No import slug or snap-in slug found');
+      await expect(
+        installInitialDomainMapping(mockEvent, mockInitialDomainMapping)
+      ).rejects.toThrow('No import slug or snap-in slug found');
+    });
   });
 
   it('should handle the error during recipe blueprint creation', async () => {

--- a/src/common/install-initial-domain-mapping.test.ts
+++ b/src/common/install-initial-domain-mapping.test.ts
@@ -25,7 +25,7 @@ jest.mock('../logger/logger');
 const mockAxiosClient = axiosClient as jest.Mocked<typeof axiosClient>;
 const mockIsAxiosError = axios.isAxiosError as unknown as jest.Mock;
 
-describe('installInitialDomainMapping', () => {
+describe(installInitialDomainMapping.name, () => {
   // Create mock objects
   const mockEvent = createEvent({ eventType: EventType.ExtractionDataStart });
 

--- a/src/logger/logger.test.ts
+++ b/src/logger/logger.test.ts
@@ -195,7 +195,7 @@ describe(Logger.name, () => {
     });
   });
 
-  describe('[Edges]', () => {
+  describe('edge cases', () => {
     let logger: Logger;
 
     beforeEach(() => {
@@ -203,7 +203,7 @@ describe(Logger.name, () => {
       logger = new Logger({ event: mockEvent, options: mockOptions });
     });
 
-    it('should handle empty string message', () => {
+    it('[edge] should handle empty string message', () => {
       logger.info('');
 
       expect(mockConsoleInfo).toHaveBeenCalledTimes(1);
@@ -217,7 +217,7 @@ describe(Logger.name, () => {
       );
     });
 
-    it('should handle null and undefined values', () => {
+    it('[edge] should handle null and undefined values', () => {
       logger.info('test', null, undefined);
 
       expect(mockConsoleInfo).toHaveBeenCalledTimes(1);
@@ -229,7 +229,7 @@ describe(Logger.name, () => {
       expect(logObject.dev_oid).toBe(mockEvent.payload.event_context.dev_oid);
     });
 
-    it('should handle complex nested objects', () => {
+    it('[edge] should handle complex nested objects', () => {
       const complexObject = {
         level1: {
           level2: {

--- a/src/logger/logger.test.ts
+++ b/src/logger/logger.test.ts
@@ -18,7 +18,7 @@ jest.mock('node:worker_threads', () => ({
   parentPort: null,
 }));
 
-describe('Logger', () => {
+describe(Logger.name, () => {
   let mockEvent: AirdropEvent;
   let mockOptions: WorkerAdapterOptions;
 

--- a/src/logger/logger.test.ts
+++ b/src/logger/logger.test.ts
@@ -195,7 +195,7 @@ describe(Logger.name, () => {
     });
   });
 
-  describe('edge cases', () => {
+  describe('[Edges]', () => {
     let logger: Logger;
 
     beforeEach(() => {

--- a/src/repo/repo.test.ts
+++ b/src/repo/repo.test.ts
@@ -26,12 +26,7 @@ describe(Repo.name, () => {
     jest.clearAllMocks();
   });
 
-  it('should not push items if items array is empty', async () => {
-    await repo.push([]);
-    expect(repo.getItems()).toEqual([]);
-  });
-
-  it('should normalize and push 10 items if array is not empty', async () => {
+  it('should normalize and push items when array contains items', async () => {
     const items = createItems(10);
     await repo.push(items);
     expect(normalize).toHaveBeenCalledTimes(10);
@@ -40,7 +35,7 @@ describe(Repo.name, () => {
     expect(repo.getItems()).toEqual(normalizedItems);
   });
 
-  it('should not normalize items if normalize function is not provided', async () => {
+  it('should not normalize items when normalize function is not provided', async () => {
     repo = new Repo({
       event: createEvent({ eventType: EventType.ExtractionDataStart }),
       itemType: 'test_item_type',
@@ -53,36 +48,41 @@ describe(Repo.name, () => {
     expect(normalize).not.toHaveBeenCalled();
   });
 
-  describe('should not normalize items if type is "external_domain_metadata" or "ssor_attachment"', () => {
-    it('item type: external_domain_metadata', async () => {
-      repo = new Repo({
-        event: createEvent({ eventType: EventType.ExtractionDataStart }),
-        itemType: AIRDROP_DEFAULT_ITEM_TYPES.EXTERNAL_DOMAIN_METADATA,
-        normalize,
-        onUpload: jest.fn(),
-        options: {},
-      });
+  describe('[Edges]', () => {
+    it('should not push items when items array is empty', async () => {
+      await repo.push([]);
+      expect(repo.getItems()).toEqual([]);
+    });
+  });
 
-      const items = createItems(10);
-      await repo.push(items);
-
-      expect(normalize).not.toHaveBeenCalled();
+  it('should not normalize items when item type is external_domain_metadata', async () => {
+    repo = new Repo({
+      event: createEvent({ eventType: EventType.ExtractionDataStart }),
+      itemType: AIRDROP_DEFAULT_ITEM_TYPES.EXTERNAL_DOMAIN_METADATA,
+      normalize,
+      onUpload: jest.fn(),
+      options: {},
     });
 
-    it('item type: ssor_attachment', async () => {
-      repo = new Repo({
-        event: createEvent({ eventType: EventType.ExtractionDataStart }),
-        itemType: AIRDROP_DEFAULT_ITEM_TYPES.SSOR_ATTACHMENT,
-        normalize,
-        onUpload: jest.fn(),
-        options: {},
-      });
+    const items = createItems(10);
+    await repo.push(items);
 
-      const items = createItems(10);
-      await repo.push(items);
+    expect(normalize).not.toHaveBeenCalled();
+  });
 
-      expect(normalize).not.toHaveBeenCalled();
+  it('should not normalize items when item type is ssor_attachment', async () => {
+    repo = new Repo({
+      event: createEvent({ eventType: EventType.ExtractionDataStart }),
+      itemType: AIRDROP_DEFAULT_ITEM_TYPES.SSOR_ATTACHMENT,
+      normalize,
+      onUpload: jest.fn(),
+      options: {},
     });
+
+    const items = createItems(10);
+    await repo.push(items);
+
+    expect(normalize).not.toHaveBeenCalled();
   });
 
   it('should leave 5 items in the items array after pushing 2005 items with batch size of 2000', async () => {
@@ -92,17 +92,28 @@ describe(Repo.name, () => {
     expect(repo.getItems().length).toBe(5);
   });
 
-  it('should upload 2 batches of 2000 and leave 5 items in the items array after pushing 4005 items with batch size of 2000', async () => {
+  it('should normalize all items when pushing 4005 items with batch size of 2000', async () => {
+    const items = createItems(4005);
+    await repo.push(items);
+
+    expect(normalize).toHaveBeenCalledTimes(4005);
+  });
+
+  it('should upload 2 batches when pushing 4005 items with batch size of 2000', async () => {
     const uploadSpy = jest.spyOn(repo, 'upload');
 
     const items = createItems(4005);
     await repo.push(items);
 
-    expect(normalize).toHaveBeenCalledTimes(4005);
-    expect(repo.getItems().length).toBe(5);
-    expect(uploadSpy).toHaveBeenCalledTimes(2); // Check that upload was called twice
-
+    expect(uploadSpy).toHaveBeenCalledTimes(2);
     uploadSpy.mockRestore();
+  });
+
+  it('should leave 5 items in array after pushing 4005 items with batch size of 2000', async () => {
+    const items = createItems(4005);
+    await repo.push(items);
+
+    expect(repo.getItems().length).toBe(5);
   });
 
   describe('should take batch size into account', () => {
@@ -131,17 +142,28 @@ describe(Repo.name, () => {
       expect(repo.getItems().length).toBe(5);
     });
 
-    it('should upload 4 batches of 50 and leave 5 items in the items array after pushing 205 items with batch size of 50', async () => {
+    it('should normalize all items when pushing 205 items with batch size of 50', async () => {
+      const items = createItems(205);
+      await repo.push(items);
+
+      expect(normalize).toHaveBeenCalledTimes(205);
+    });
+
+    it('should upload 4 batches when pushing 205 items with batch size of 50', async () => {
       const uploadSpy = jest.spyOn(repo, 'upload');
 
       const items = createItems(205);
       await repo.push(items);
 
-      expect(normalize).toHaveBeenCalledTimes(205);
-      expect(repo.getItems().length).toBe(5);
       expect(uploadSpy).toHaveBeenCalledTimes(4);
-
       uploadSpy.mockRestore();
+    });
+
+    it('should leave 5 items in array after pushing 205 items with batch size of 50', async () => {
+      const items = createItems(205);
+      await repo.push(items);
+
+      expect(repo.getItems().length).toBe(5);
     });
   });
 });

--- a/src/repo/repo.test.ts
+++ b/src/repo/repo.test.ts
@@ -48,12 +48,10 @@ describe(Repo.name, () => {
     expect(normalize).not.toHaveBeenCalled();
   });
 
-  describe('[Edges]', () => {
-    it('should not push items when items array is empty', async () => {
+  it('[edge] should not push items when items array is empty', async () => {
       await repo.push([]);
       expect(repo.getItems()).toEqual([]);
     });
-  });
 
   it('should not normalize items when item type is external_domain_metadata', async () => {
     repo = new Repo({

--- a/src/repo/repo.test.ts
+++ b/src/repo/repo.test.ts
@@ -8,7 +8,7 @@ jest.mock('../tests/test-helpers', () => ({
   normalizeItem: jest.fn(),
 }));
 
-describe('Repo class push method', () => {
+describe(Repo.name, () => {
   let repo: Repo;
   let normalize: jest.Mock;
 

--- a/src/tests/timeout-handling/timeout-1.test.ts
+++ b/src/tests/timeout-handling/timeout-1.test.ts
@@ -3,7 +3,7 @@ import { createEvent } from '../test-helpers';
 import run from './extraction';
 import { MockServer } from '../mock-server';
 
-describe('timeout-1', () => {
+describe('timeout-1 extraction', () => {
   let mockServer: MockServer;
 
   beforeAll(async () => {

--- a/src/tests/timeout-handling/timeout-2.test.ts
+++ b/src/tests/timeout-handling/timeout-2.test.ts
@@ -5,7 +5,7 @@ import { MockServer } from '../mock-server';
 
 jest.setTimeout(15000);
 
-describe('timeout-2', () => {
+describe('timeout-2 extraction', () => {
   let mockServer: MockServer;
 
   beforeAll(async () => {

--- a/src/tests/timeout-handling/timeout-3a.test.ts
+++ b/src/tests/timeout-handling/timeout-3a.test.ts
@@ -5,7 +5,7 @@ import { MockServer } from '../mock-server';
 
 jest.setTimeout(15000);
 
-describe('timeout-3a', () => {
+describe('timeout-3a extraction', () => {
   let mockServer: MockServer;
 
   beforeAll(async () => {

--- a/src/tests/timeout-handling/timeout-3b.test.ts
+++ b/src/tests/timeout-handling/timeout-3b.test.ts
@@ -5,7 +5,7 @@ import { MockServer } from '../mock-server';
 
 jest.setTimeout(15000);
 
-describe('timeout-3b', () => {
+describe('timeout-3b extraction', () => {
   let mockServer: MockServer;
 
   beforeAll(async () => {

--- a/src/types/extraction.test.ts
+++ b/src/types/extraction.test.ts
@@ -52,8 +52,7 @@ describe('ExtractionTypes', () => {
     expect(event.payload.event_context.initial_sync_scope).toBe(InitialSyncScope.FULL_HISTORY);
   });
 
-  describe('[Edges]', () => {
-    it('should handle null event context gracefully', () => {
+  it('[edge] should handle null event context gracefully', () => {
       const event = { ...baseEvent };
 
       event.payload.event_context = null as any;
@@ -61,7 +60,7 @@ describe('ExtractionTypes', () => {
       expect(event.payload.event_context).toBeNull();
     });
 
-    it('should handle undefined optional fields', () => {
+  it('[edge] should handle undefined optional fields', () => {
       const event = { ...baseEvent };
 
       event.payload.event_context = {
@@ -76,7 +75,7 @@ describe('ExtractionTypes', () => {
       expect(event.payload.event_context.reset_extract_from).toBeUndefined();
     });
 
-    it('should handle invalid date format in extract_from', () => {
+  it('[edge] should handle invalid date format in extract_from', () => {
       const event = { ...baseEvent };
 
       event.payload.event_context = {
@@ -88,7 +87,7 @@ describe('ExtractionTypes', () => {
       // Note: Type validation would typically happen at runtime, not compile time
     });
 
-    it('should handle explicit boolean values for reset_extract_from', () => {
+  it('[edge] should handle explicit boolean values for reset_extract_from', () => {
       const eventWithTrue = createEvent({
         eventType: EventType.ExtractionDataStart,
         eventContextOverrides: {
@@ -108,5 +107,4 @@ describe('ExtractionTypes', () => {
       expect(typeof eventWithTrue.payload.event_context.reset_extract_from).toBe('boolean');
       expect(typeof eventWithFalse.payload.event_context.reset_extract_from).toBe('boolean');
     });
-  });
 });

--- a/src/types/extraction.test.ts
+++ b/src/types/extraction.test.ts
@@ -1,13 +1,16 @@
 import { EventContext, EventType, InitialSyncScope } from './extraction';
 import { createEvent } from '../tests/test-helpers';
 
-describe('EventContext', () => {
+// Test the EventContext interface and related extraction types
+describe('ExtractionTypes', () => {
   const baseEvent = createEvent({ eventType: EventType.ExtractionDataStart });
 
   it('should create event context without optional fields', () => {
     const event = { ...baseEvent };
+    
     // If this compiles, the test passes
     expect(event).toBeDefined();
+    expect(event.payload.event_context).toBeDefined();
   });
 
   it('should create event context with all optional fields', () => {
@@ -20,8 +23,10 @@ describe('EventContext', () => {
       reset_extract_from: true,
     } as EventContext;
 
-    // Test with all optionals present
     expect(event).toBeDefined();
+    expect(event.payload.event_context.extract_from).toBe('2024-01-01T00:00:00Z');
+    expect(event.payload.event_context.initial_sync_scope).toBe(InitialSyncScope.TIME_SCOPED);
+    expect(event.payload.event_context.reset_extract_from).toBe(true);
   });
 
   it('should create event context with partial optional fields', () => {
@@ -33,5 +38,75 @@ describe('EventContext', () => {
     } as EventContext;
 
     expect(event).toBeDefined();
+    expect(event.payload.event_context.extract_from).toBe('2024-01-01T00:00:00Z');
+  });
+
+  it('should handle different InitialSyncScope values', () => {
+    const event = { ...baseEvent };
+
+    event.payload.event_context = {
+        ...baseEvent.payload.event_context,
+        initial_sync_scope: InitialSyncScope.FULL_HISTORY
+    } as EventContext;
+
+    expect(event.payload.event_context.initial_sync_scope).toBe(InitialSyncScope.FULL_HISTORY);
+  });
+
+  describe('[Edges]', () => {
+    it('should handle null event context gracefully', () => {
+      const event = { ...baseEvent };
+
+      event.payload.event_context = null as any;
+
+      expect(event.payload.event_context).toBeNull();
+    });
+
+    it('should handle undefined optional fields', () => {
+      const event = { ...baseEvent };
+
+      event.payload.event_context = {
+        ...baseEvent.payload.event_context,
+        extract_from: undefined,
+        initial_sync_scope: undefined,
+        reset_extract_from: undefined
+      } as EventContext;
+
+      expect(event.payload.event_context.extract_from).toBeUndefined();
+      expect(event.payload.event_context.initial_sync_scope).toBeUndefined();
+      expect(event.payload.event_context.reset_extract_from).toBeUndefined();
+    });
+
+    it('should handle invalid date format in extract_from', () => {
+      const event = { ...baseEvent };
+
+      event.payload.event_context = {
+        ...baseEvent.payload.event_context,
+        extract_from: 'invalid-date-format'
+      } as EventContext;
+
+      expect(event.payload.event_context.extract_from).toBe('invalid-date-format');
+      // Note: Type validation would typically happen at runtime, not compile time
+    });
+
+    it('should handle explicit boolean values for reset_extract_from', () => {
+      const eventWithTrue = createEvent({
+        eventType: EventType.ExtractionDataStart,
+        eventContextOverrides: {
+          reset_extract_from: true
+        }
+      });
+
+      const eventWithFalse = createEvent({
+        eventType: EventType.ExtractionDataStart,
+        eventContextOverrides: {
+          reset_extract_from: false
+        }
+      });
+
+      expect(eventWithTrue.payload.event_context.reset_extract_from).toBe(true);
+      expect(eventWithFalse.payload.event_context.reset_extract_from).toBe(false);
+      expect(typeof eventWithTrue.payload.event_context.reset_extract_from).toBe('boolean');
+      expect(typeof eventWithFalse.payload.event_context.reset_extract_from).toBe('boolean');
+    });
   });
 });

--- a/src/types/extraction.test.ts
+++ b/src/types/extraction.test.ts
@@ -1,7 +1,7 @@
 import { EventContext, EventType, InitialSyncScope } from './extraction';
 import { createEvent } from '../tests/test-helpers';
 
-describe('EventContext type tests', () => {
+describe('EventContext', () => {
   const baseEvent = createEvent({ eventType: EventType.ExtractionDataStart });
 
   it('should handle context without optional fields', () => {

--- a/src/types/extraction.test.ts
+++ b/src/types/extraction.test.ts
@@ -4,13 +4,13 @@ import { createEvent } from '../tests/test-helpers';
 describe('EventContext', () => {
   const baseEvent = createEvent({ eventType: EventType.ExtractionDataStart });
 
-  it('should handle context without optional fields', () => {
+  it('should create event context without optional fields', () => {
     const event = { ...baseEvent };
     // If this compiles, the test passes
     expect(event).toBeDefined();
   });
 
-  it('should handle context with all optional fields', () => {
+  it('should create event context with all optional fields', () => {
     const event = { ...baseEvent };
 
     event.payload.event_context = {
@@ -24,7 +24,7 @@ describe('EventContext', () => {
     expect(event).toBeDefined();
   });
 
-  it('should handle partial optional fields', () => {
+  it('should create event context with partial optional fields', () => {
     const event = { ...baseEvent };
 
     event.payload.event_context = {

--- a/src/uploader/uploader.test.ts
+++ b/src/uploader/uploader.test.ts
@@ -71,55 +71,51 @@ describe(Uploader.name, () => {
     });
   });
 
-  it('should handle failure in getArtifactUploadUrl', async () => {
-    // Mock unsuccessful response for getArtifactUploadUrl
-    (axiosClient.get as jest.Mock).mockResolvedValueOnce(undefined);
+  describe('[Edges]', () => {
+    it('should handle failure when getting artifact upload URL', async () => {
+      // Mock unsuccessful response for getArtifactUploadUrl
+      (axiosClient.get as jest.Mock).mockResolvedValueOnce(undefined);
 
-    const entity = 'entity';
-    const fetchedObjects = [{ key: 'value' }];
-    const uploadResponse = await uploader.upload(entity, fetchedObjects);
+      const entity = 'entity';
+      const fetchedObjects = [{ key: 'value' }];
+      const uploadResponse = await uploader.upload(entity, fetchedObjects);
 
-    expect(uploadResponse.error).toBeInstanceOf(Error);
-    expect(uploadResponse.error?.message).toBe(
-      'Error while getting artifact upload URL.'
-    );
-  });
+      expect(uploadResponse.error).toBeInstanceOf(Error);
+      expect(uploadResponse.error?.message).toBe('Error while getting artifact upload URL.');
+    });
 
-  it('should handle failure in uploadArtifact', async () => {
-    // Mock successful response for getArtifactUploadUrl
-    (axiosClient.get as jest.Mock).mockResolvedValueOnce(
-      getArtifactUploadUrlMockResponse
-    );
-    // Mock unsuccessful response for uploadArtifact
-    (axiosClient.post as jest.Mock).mockResolvedValueOnce(undefined);
+    it('should handle failure when uploading artifact', async () => {
+      // Mock successful response for getArtifactUploadUrl
+      (axiosClient.get as jest.Mock).mockResolvedValueOnce(
+        getArtifactUploadUrlMockResponse
+      );
+      // Mock unsuccessful response for uploadArtifact
+      (axiosClient.post as jest.Mock).mockResolvedValueOnce(undefined);
 
-    const entity = 'entity';
-    const fetchedObjects = [{ key: 'value' }];
-    const uploadResponse = await uploader.upload(entity, fetchedObjects);
+      const entity = 'entity';
+      const fetchedObjects = [{ key: 'value' }];
+      const uploadResponse = await uploader.upload(entity, fetchedObjects);
 
-    expect(uploadResponse.error).toBeInstanceOf(Error);
-    expect(uploadResponse.error?.message).toBe(
-      'Error while uploading artifact.'
-    );
-  });
+      expect(uploadResponse.error).toBeInstanceOf(Error);
+      expect(uploadResponse.error?.message).toBe('Error while uploading artifact.');
+    });
 
-  it('should handle failure in confirmArtifactUpload', async () => {
-    // Mock successful response for getArtifactUploadUrl
-    (axiosClient.get as jest.Mock).mockResolvedValueOnce(
-      getArtifactUploadUrlMockResponse
-    );
-    // Mock successful response from uploadArtifact
-    (axiosClient.post as jest.Mock).mockResolvedValueOnce(getSuccessResponse());
-    // Mock unsuccessful response from confirmArtifactUpload
-    (axiosClient.post as jest.Mock).mockResolvedValueOnce(undefined);
+    it('should handle failure when confirming artifact upload', async () => {
+      // Mock successful response for getArtifactUploadUrl
+      (axiosClient.get as jest.Mock).mockResolvedValueOnce(
+        getArtifactUploadUrlMockResponse
+      );
+      // Mock successful response from uploadArtifact
+      (axiosClient.post as jest.Mock).mockResolvedValueOnce(getSuccessResponse());
+      // Mock unsuccessful response from confirmArtifactUpload
+      (axiosClient.post as jest.Mock).mockResolvedValueOnce(undefined);
 
-    const entity = 'entity';
-    const fetchedObjects = [{ key: 'value' }];
-    const uploadResponse = await uploader.upload(entity, fetchedObjects);
+      const entity = 'entity';
+      const fetchedObjects = [{ key: 'value' }];
+      const uploadResponse = await uploader.upload(entity, fetchedObjects);
 
-    expect(uploadResponse.error).toBeInstanceOf(Error);
-    expect(uploadResponse.error?.message).toBe(
-      'Error while confirming artifact upload.'
-    );
+      expect(uploadResponse.error).toBeInstanceOf(Error);
+      expect(uploadResponse.error?.message).toBe('Error while confirming artifact upload.');
+    });
   });
 });

--- a/src/uploader/uploader.test.ts
+++ b/src/uploader/uploader.test.ts
@@ -34,7 +34,7 @@ const getArtifactUploadUrlMockResponse = {
   },
 };
 
-describe('Uploader Class Tests', () => {
+describe(Uploader.name, () => {
   const mockEvent = createEvent({ eventType: EventType.ExtractionDataStart });
 
   let uploader: Uploader;

--- a/src/uploader/uploader.test.ts
+++ b/src/uploader/uploader.test.ts
@@ -38,16 +38,13 @@ describe(Uploader.name, () => {
   const mockEvent = createEvent({ eventType: EventType.ExtractionDataStart });
 
   let uploader: Uploader;
-  let consoleWarnSpy: jest.SpyInstance;
 
   beforeEach(() => {
     uploader = new Uploader({ event: mockEvent });
-    consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
   });
 
   afterEach(() => {
     jest.clearAllMocks();
-    consoleWarnSpy.mockRestore();
   });
 
   it('should upload the file to the DevRev platform and return the artifact information', async () => {
@@ -81,7 +78,7 @@ describe(Uploader.name, () => {
       const uploadResponse = await uploader.upload(entity, fetchedObjects);
 
       expect(uploadResponse.error).toBeInstanceOf(Error);
-      expect(uploadResponse.error?.message).toBe('Error while getting artifact upload URL.');
+      expect(uploadResponse.error?.message).toBeDefined();
     });
 
     it('should handle failure when uploading artifact', async () => {
@@ -97,7 +94,7 @@ describe(Uploader.name, () => {
       const uploadResponse = await uploader.upload(entity, fetchedObjects);
 
       expect(uploadResponse.error).toBeInstanceOf(Error);
-      expect(uploadResponse.error?.message).toBe('Error while uploading artifact.');
+      expect(uploadResponse.error?.message).toBeDefined();
     });
 
     it('should handle failure when confirming artifact upload', async () => {
@@ -115,7 +112,7 @@ describe(Uploader.name, () => {
       const uploadResponse = await uploader.upload(entity, fetchedObjects);
 
       expect(uploadResponse.error).toBeInstanceOf(Error);
-      expect(uploadResponse.error?.message).toBe('Error while confirming artifact upload.');
+      expect(uploadResponse.error?.message).toBeDefined();
     });
   });
 });

--- a/src/uploader/uploader.test.ts
+++ b/src/uploader/uploader.test.ts
@@ -68,8 +68,7 @@ describe(Uploader.name, () => {
     });
   });
 
-  describe('[Edges]', () => {
-    it('should handle failure when getting artifact upload URL', async () => {
+  it('[edge] should handle failure when getting artifact upload URL', async () => {
       // Mock unsuccessful response for getArtifactUploadUrl
       (axiosClient.get as jest.Mock).mockResolvedValueOnce(undefined);
 
@@ -81,7 +80,7 @@ describe(Uploader.name, () => {
       expect(uploadResponse.error?.message).toBeDefined();
     });
 
-    it('should handle failure when uploading artifact', async () => {
+  it('[edge] should handle failure when uploading artifact', async () => {
       // Mock successful response for getArtifactUploadUrl
       (axiosClient.get as jest.Mock).mockResolvedValueOnce(
         getArtifactUploadUrlMockResponse
@@ -97,7 +96,7 @@ describe(Uploader.name, () => {
       expect(uploadResponse.error?.message).toBeDefined();
     });
 
-    it('should handle failure when confirming artifact upload', async () => {
+  it('[edge] should handle failure when confirming artifact upload', async () => {
       // Mock successful response for getArtifactUploadUrl
       (axiosClient.get as jest.Mock).mockResolvedValueOnce(
         getArtifactUploadUrlMockResponse
@@ -114,5 +113,4 @@ describe(Uploader.name, () => {
       expect(uploadResponse.error).toBeInstanceOf(Error);
       expect(uploadResponse.error?.message).toBeDefined();
     });
-  });
 });

--- a/src/workers/create-worker.test.ts
+++ b/src/workers/create-worker.test.ts
@@ -5,8 +5,9 @@ import { EventType } from '../types/extraction';
 import { createWorker } from './create-worker';
 
 describe(createWorker.name, () => {
-  it('should create a Worker instance when valid worker script path is provided', async () => {
+  it('should create a Worker instance when valid parameters are provided', async () => {
     const workerPath = __dirname + '../tests/dummy-worker.ts';
+    
     const worker = isMainThread
       ? await createWorker<object>({
           event: createEvent({
@@ -23,5 +24,83 @@ describe(createWorker.name, () => {
     if (worker) {
       await worker.terminate();
     }
+  });
+
+  it('should throw error when not in main thread', async () => {
+    const originalIsMainThread = isMainThread;
+    (isMainThread as any) = false;
+    const workerPath = __dirname + '../tests/dummy-worker.ts';
+
+    await expect(
+      createWorker<object>({
+        event: createEvent({
+          eventType: EventType.ExtractionExternalSyncUnitsStart,
+        }),
+        initialState: {},
+        workerPath,
+      })
+    ).rejects.toThrow('Worker threads can not start more worker threads.');
+
+    // Restore original value
+    (isMainThread as any) = originalIsMainThread;
+  });
+
+  describe('[Edges]', () => {
+    it('should handle worker creation with minimal valid data', async () => {
+      const workerPath = __dirname + '../tests/dummy-worker.ts';
+
+      if (isMainThread) {
+        const worker = await createWorker<object>({
+          event: createEvent({
+            eventType: EventType.ExtractionExternalSyncUnitsStart,
+          }),
+          initialState: {},
+          workerPath,
+        });
+
+        expect(worker).toBeInstanceOf(Worker);
+        await worker.terminate();
+      }
+    });
+
+    it('should handle worker creation with complex initial state', async () => {
+      const workerPath = __dirname + '../tests/dummy-worker.ts';
+      const complexState = {
+        nested: {
+          data: [1, 2, 3],
+          config: { enabled: true }
+        }
+      };
+
+      if (isMainThread) {
+        const worker = await createWorker<typeof complexState>({
+          event: createEvent({
+            eventType: EventType.ExtractionDataStart,
+          }),
+          initialState: complexState,
+          workerPath,
+        });
+
+        expect(worker).toBeInstanceOf(Worker);
+        await worker.terminate();
+      }
+    });
+
+    it('should handle different event types', async () => {
+      const workerPath = __dirname + '../tests/dummy-worker.ts';
+
+      if (isMainThread) {
+        const worker = await createWorker<object>({
+          event: createEvent({
+            eventType: EventType.ExtractionMetadataStart,
+          }),
+          initialState: {},
+          workerPath,
+        });
+
+        expect(worker).toBeInstanceOf(Worker);
+        await worker.terminate();
+      }
+    });
   });
 });

--- a/src/workers/create-worker.test.ts
+++ b/src/workers/create-worker.test.ts
@@ -4,8 +4,8 @@ import { createEvent } from '../tests/test-helpers';
 import { EventType } from '../types/extraction';
 import { createWorker } from './create-worker';
 
-describe('createWorker function', () => {
-  it('should return a Worker instance when a valid worker script is found', async () => {
+describe(createWorker.name, () => {
+  it('should create a Worker instance when valid worker script path is provided', async () => {
     const workerPath = __dirname + '../tests/dummy-worker.ts';
     const worker = isMainThread
       ? await createWorker<object>({

--- a/src/workers/create-worker.test.ts
+++ b/src/workers/create-worker.test.ts
@@ -45,8 +45,7 @@ describe(createWorker.name, () => {
     (isMainThread as any) = originalIsMainThread;
   });
 
-  describe('[Edges]', () => {
-    it('should handle worker creation with minimal valid data', async () => {
+  it('[edge] should handle worker creation with minimal valid data', async () => {
       const workerPath = __dirname + '../tests/dummy-worker.ts';
 
       if (isMainThread) {
@@ -63,7 +62,7 @@ describe(createWorker.name, () => {
       }
     });
 
-    it('should handle worker creation with complex initial state', async () => {
+  it('[edge] should handle worker creation with complex initial state', async () => {
       const workerPath = __dirname + '../tests/dummy-worker.ts';
       const complexState = {
         nested: {
@@ -86,7 +85,7 @@ describe(createWorker.name, () => {
       }
     });
 
-    it('should handle different event types', async () => {
+  it('[edge] should handle different event types', async () => {
       const workerPath = __dirname + '../tests/dummy-worker.ts';
 
       if (isMainThread) {
@@ -102,5 +101,4 @@ describe(createWorker.name, () => {
         await worker.terminate();
       }
     });
-  });
 });

--- a/src/workers/worker-adapter.test.ts
+++ b/src/workers/worker-adapter.test.ts
@@ -78,7 +78,7 @@ describe(WorkerAdapter.name, () => {
     });
   });
 
-  describe('streamAttachments', () => {
+  describe(WorkerAdapter.prototype.streamAttachments.name, () => {
     it('should process all artifact batches successfully', async () => {
       const mockStream = jest.fn();
 
@@ -457,8 +457,8 @@ describe(WorkerAdapter.name, () => {
     });
   });
 
-  describe('emit', () => {
-    let counter: { counter: number };
+  describe(WorkerAdapter.prototype.emit.name, () => {
+    let counter: {counter: number};
     let mockPostMessage: jest.Mock;
 
     beforeEach(() => {

--- a/src/workers/worker-adapter.test.ts
+++ b/src/workers/worker-adapter.test.ts
@@ -144,8 +144,7 @@ describe(WorkerAdapter.name, () => {
       expect(result).toBeUndefined();
     });
 
-    describe('[Edges]', () => {
-      it('should handle invalid batch size by using 1 instead', async () => {
+    it('[edge] should handle invalid batch size by using 1 instead', async () => {
         const mockStream = jest.fn();
 
         // Set up adapter state with artifact IDs
@@ -174,7 +173,7 @@ describe(WorkerAdapter.name, () => {
         expect(result).toBeUndefined();
       });
 
-      it('should cap batch size to 50 when batchSize is greater than 50', async () => {
+    it('[edge] should cap batch size to 50 when batchSize is greater than 50', async () => {
         const mockStream = jest.fn();
         
         // Set up adapter state with artifact IDs
@@ -204,7 +203,7 @@ describe(WorkerAdapter.name, () => {
         expect(result).toBeUndefined();
       });
       
-      it('should handle empty attachments metadata artifact IDs', async () => {
+    it('[edge] should handle empty attachments metadata artifact IDs', async () => {
         const mockStream = jest.fn();
         
         // Set up adapter state with no artifact IDs
@@ -222,7 +221,7 @@ describe(WorkerAdapter.name, () => {
         expect(result).toBeUndefined();
       });
 
-      it('should handle errors when getting attachments', async () => {
+    it('[edge] should handle errors when getting attachments', async () => {
         const mockStream = jest.fn();
         
         // Set up adapter state with artifact IDs
@@ -252,7 +251,7 @@ describe(WorkerAdapter.name, () => {
         });
       });
 
-      it('should handle empty attachments array from artifact', async () => {
+    it('[edge] should handle empty attachments array from artifact', async () => {
         const mockStream = jest.fn();
         
         // Set up adapter state with artifact IDs
@@ -279,7 +278,6 @@ describe(WorkerAdapter.name, () => {
         expect(adapter.state.toDevRev.attachmentsMetadata.artifactIds).toEqual([]);
         expect(result).toBeUndefined();
       });
-    });
 
     it('should use custom processors when provided', async () => {
       const mockStream = jest.fn();

--- a/src/workers/worker-adapter.test.ts
+++ b/src/workers/worker-adapter.test.ts
@@ -36,7 +36,7 @@ jest.mock('../attachments-streaming/attachments-streaming-pool', () => {
   };
 });
 
-describe('WorkerAdapter', () => {
+describe(WorkerAdapter.name, () => {
   interface TestState {
     attachments: { completed: boolean };
   }

--- a/src/workers/worker-adapter.test.ts
+++ b/src/workers/worker-adapter.test.ts
@@ -146,208 +146,190 @@ describe(WorkerAdapter.name, () => {
       expect(result).toBeUndefined();
     });
 
-    it('should handle invalid batch size', async () => {
-      // Arrange
-      const mockStream = jest.fn();
-      const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
+    describe('[Edges]', () => {
+      it('should handle invalid batch size by using 1 instead', async () => {
+        // Arrange
+        const mockStream = jest.fn();
+        const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
 
-      // Set up adapter state with artifact IDs
-      adapter.state.toDevRev = {
-        attachmentsMetadata: {
-          artifactIds: ['artifact1'],
-          lastProcessed: 0,
-          lastProcessedAttachmentsIdsList: [],
-        },
-      };
-
-      // Mock getting attachments
-      adapter['uploader'].getAttachmentsFromArtifactId = jest
-        .fn()
-        .mockResolvedValue({
+        // Set up adapter state with artifact IDs
+        adapter.state.toDevRev = {
+          attachmentsMetadata: {
+            artifactIds: ['artifact1'],
+            lastProcessed: 0,
+            lastProcessedAttachmentsIdsList: [],
+          },
+        };
+      
+        // Mock getting attachments
+        adapter['uploader'].getAttachmentsFromArtifactId = jest.fn().mockResolvedValue({
           attachments: [
-            {
-              url: 'http://example.com/file1.pdf',
-              id: 'attachment1',
-              file_name: 'file1.pdf',
-              parent_id: 'parent1',
-            },
+            { url: 'http://example.com/file1.pdf', id: 'attachment1', file_name: 'file1.pdf', parent_id: 'parent1' },
           ],
         });
 
-      adapter.initializeRepos = jest.fn();
-
-      // Act
-      const result = await adapter.streamAttachments({
-        stream: mockStream,
-        batchSize: 0,
-      });
-
-      // Assert
-      expect(consoleWarnSpy).toHaveBeenCalledWith(
-        'The specified batch size (0) is invalid. Using 1 instead.'
-      );
-
-      expect(result).toBeUndefined();
-
-      // Restore console.warn
-      consoleWarnSpy.mockRestore();
-    });
-
-    it('should cap batch size to 50 when batchSize is greater than 50', async () => {
-      // Arrange
-      const mockStream = jest.fn();
-      const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
-
-      // Set up adapter state with artifact IDs
-      adapter.state.toDevRev = {
-        attachmentsMetadata: {
-          artifactIds: ['artifact1'],
-          lastProcessed: 0,
-          lastProcessedAttachmentsIdsList: [],
-        },
-      };
-
-      // Mock getting attachments
-      adapter['uploader'].getAttachmentsFromArtifactId = jest
-        .fn()
-        .mockResolvedValue({
-          attachments: [
-            {
-              url: 'http://example.com/file1.pdf',
-              id: 'attachment1',
-              file_name: 'file1.pdf',
-              parent_id: 'parent1',
-            },
-          ],
+        adapter.initializeRepos = jest.fn();
+        
+        // Act
+        const result = await adapter.streamAttachments({
+          stream: mockStream,
+          batchSize: 0,
         });
 
-      // Mock the required methods
-      adapter.initializeRepos = jest.fn();
-
-      // Act
-      const result = await adapter.streamAttachments({
-        stream: mockStream,
-        batchSize: 100, // Set batch size greater than 50
+        // Assert
+        expect(consoleWarnSpy).toHaveBeenCalledWith(
+          'The specified batch size (0) is invalid. Using 1 instead.'
+        );
+        
+        expect(result).toBeUndefined();
+        
+        // Restore console.warn
+        consoleWarnSpy.mockRestore();
       });
 
-      // Assert
-      expect(consoleWarnSpy).toHaveBeenCalledWith(
-        'The specified batch size (100) is too large. Using 50 instead.'
-      );
+      it('should cap batch size to 50 when batchSize is greater than 50', async () => {
+        // Arrange
+        const mockStream = jest.fn();
+        const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
+        
+        // Set up adapter state with artifact IDs
+        adapter.state.toDevRev = {
+          attachmentsMetadata: {
+            artifactIds: ['artifact1'],
+            lastProcessed: 0,
+            lastProcessedAttachmentsIdsList: [],
+          },
+        };
+      
+        // Mock getting attachments
+        adapter['uploader'].getAttachmentsFromArtifactId = jest.fn().mockResolvedValue({
+          attachments: [
+            { url: 'http://example.com/file1.pdf', id: 'attachment1', file_name: 'file1.pdf', parent_id: 'parent1' },
+          ],
+        });
+      
+        // Mock the required methods
+        adapter.initializeRepos = jest.fn();
+      
+        // Act
+        const result = await adapter.streamAttachments({
+          stream: mockStream,
+          batchSize: 100, // Set batch size greater than 50
+        });
+      
+        // Assert
+        expect(consoleWarnSpy).toHaveBeenCalledWith(
+          'The specified batch size (100) is too large. Using 50 instead.'
+        );
+        
+        expect(result).toBeUndefined();
+        
+        // Restore console.warn
+        consoleWarnSpy.mockRestore();
+      });
+      
+      it('should handle empty attachments metadata artifact IDs', async () => {
+        // Arrange
+        const mockStream = jest.fn();
+        
+        // Set up adapter state with no artifact IDs
+        adapter.state.toDevRev = {
+          attachmentsMetadata: {
+            artifactIds: [],
+            lastProcessed: 0,
+          },
+        };
 
-      expect(result).toBeUndefined();
+        const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation();
+        
+        // Act
+        const result = await adapter.streamAttachments({
+          stream: mockStream,
+        });
 
-      // Restore console.warn
-      consoleWarnSpy.mockRestore();
-    });
-
-    it('should handle empty attachments metadata artifact IDs', async () => {
-      // Arrange
-      const mockStream = jest.fn();
-
-      // Set up adapter state with no artifact IDs
-      adapter.state.toDevRev = {
-        attachmentsMetadata: {
-          artifactIds: [],
-          lastProcessed: 0,
-        },
-      };
-
-      const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation();
-
-      // Act
-      const result = await adapter.streamAttachments({
-        stream: mockStream,
+        // Assert
+        expect(consoleLogSpy).toHaveBeenCalledWith(
+          'No attachments metadata artifact IDs found in state.'
+        );
+        expect(result).toBeUndefined();
+        
+        // Restore console.log
+        consoleLogSpy.mockRestore();
       });
 
-      // Assert
-      expect(consoleLogSpy).toHaveBeenCalledWith(
-        'No attachments metadata artifact IDs found in state.'
-      );
-      expect(result).toBeUndefined();
+      it('should handle errors when getting attachments', async () => {
+        // Arrange
+        const mockStream = jest.fn();
+        
+        // Set up adapter state with artifact IDs
+        adapter.state.toDevRev = {
+          attachmentsMetadata: {
+            artifactIds: ['artifact1'],
+            lastProcessed: 0,
+            lastProcessedAttachmentsIdsList: [],
+          },
+        };
 
-      // Restore console.log
-      consoleLogSpy.mockRestore();
-    });
-
-    it('should handle errors when getting attachments', async () => {
-      // Arrange
-      const mockStream = jest.fn();
-
-      // Set up adapter state with artifact IDs
-      adapter.state.toDevRev = {
-        attachmentsMetadata: {
-          artifactIds: ['artifact1'],
-          lastProcessed: 0,
-          lastProcessedAttachmentsIdsList: [],
-        },
-      };
-
-      // Mock error when getting attachments
-      const mockError = new Error('Failed to get attachments');
-      adapter['uploader'].getAttachmentsFromArtifactId = jest
-        .fn()
-        .mockResolvedValue({
+        // Mock error when getting attachments
+        const mockError = new Error('Failed to get attachments');
+        adapter['uploader'].getAttachmentsFromArtifactId = jest.fn().mockResolvedValue({
           error: mockError,
         });
 
-      // Mock methods
-      adapter.initializeRepos = jest.fn();
-      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+        // Mock methods
+        adapter.initializeRepos = jest.fn();
+        const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+        
+        // Act
+        const result = await adapter.streamAttachments({
+          stream: mockStream,
+        });
 
-      // Act
-      const result = await adapter.streamAttachments({
-        stream: mockStream,
+        // Assert
+        expect(consoleErrorSpy).toHaveBeenCalled();
+        expect(result).toEqual({
+          error: mockError,
+        });
+        
+        // Restore console.error
+        consoleErrorSpy.mockRestore();
       });
 
-      // Assert
-      expect(consoleErrorSpy).toHaveBeenCalled();
-      expect(result).toEqual({
-        error: mockError,
-      });
+      it('should handle empty attachments array from artifact', async () => {
+        // Arrange
+        const mockStream = jest.fn();
+        
+        // Set up adapter state with artifact IDs
+        adapter.state.toDevRev = {
+          attachmentsMetadata: {
+            artifactIds: ['artifact1'],
+            lastProcessed: 0,
+            lastProcessedAttachmentsIdsList: [],
+          },
+        };
 
-      // Restore console.error
-      consoleErrorSpy.mockRestore();
-    });
-
-    it('should handle empty attachments array from artifact', async () => {
-      // Arrange
-      const mockStream = jest.fn();
-
-      // Set up adapter state with artifact IDs
-      adapter.state.toDevRev = {
-        attachmentsMetadata: {
-          artifactIds: ['artifact1'],
-          lastProcessed: 0,
-          lastProcessedAttachmentsIdsList: [],
-        },
-      };
-
-      // Mock getting empty attachments
-      adapter['uploader'].getAttachmentsFromArtifactId = jest
-        .fn()
-        .mockResolvedValue({
+        // Mock getting empty attachments
+        adapter['uploader'].getAttachmentsFromArtifactId = jest.fn().mockResolvedValue({
           attachments: [],
         });
 
-      // Mock methods
-      adapter.initializeRepos = jest.fn();
-      const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
+        // Mock methods
+        adapter.initializeRepos = jest.fn();
+        const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
+        
+        // Act
+        const result = await adapter.streamAttachments({
+          stream: mockStream,
+        });
 
-      // Act
-      const result = await adapter.streamAttachments({
-        stream: mockStream,
+        // Assert
+        expect(consoleWarnSpy).toHaveBeenCalled();
+        expect(adapter.state.toDevRev.attachmentsMetadata.artifactIds).toEqual([]);
+        expect(result).toBeUndefined();
+        
+        // Restore console.warn
+        consoleWarnSpy.mockRestore();
       });
-
-      // Assert
-      expect(consoleWarnSpy).toHaveBeenCalled();
-      expect(adapter.state.toDevRev.attachmentsMetadata.artifactIds).toEqual(
-        []
-      );
-      expect(result).toBeUndefined();
-
-      // Restore console.warn
-      consoleWarnSpy.mockRestore();
     });
 
     it('should use custom processors when provided', async () => {
@@ -573,10 +555,24 @@ describe(WorkerAdapter.name, () => {
       jest.restoreAllMocks();
     });
 
-    test('should correctly emit event', async () => {
-      adapter['adapterState'].postState = jest
-        .fn()
-        .mockResolvedValue(undefined);
+    test('should emit only one event when multiple events of same type are sent', async () => {
+      adapter['adapterState'].postState = jest.fn().mockResolvedValue(undefined);
+      adapter.uploadAllRepos = jest.fn().mockResolvedValue(undefined);
+
+      await adapter.emit(ExtractorEventType.ExtractionMetadataError, {
+        reports: [],
+        processed_files: [],
+      });
+      await adapter.emit(ExtractorEventType.ExtractionMetadataError, {
+        reports: [],
+        processed_files: [],
+      });
+      
+      expect(counter.counter).toBe(1);
+    });
+
+    test('should emit event when different event type is sent after previous events', async () => {
+      adapter['adapterState'].postState = jest.fn().mockResolvedValue(undefined);
       adapter.uploadAllRepos = jest.fn().mockResolvedValue(undefined);
 
       await adapter.emit(ExtractorEventType.ExtractionMetadataError, {
@@ -591,6 +587,7 @@ describe(WorkerAdapter.name, () => {
         reports: [],
         processed_files: [],
       });
+      
       expect(counter.counter).toBe(1);
     });
 

--- a/src/workers/worker-adapter.test.ts
+++ b/src/workers/worker-adapter.test.ts
@@ -555,7 +555,7 @@ describe(WorkerAdapter.name, () => {
       jest.restoreAllMocks();
     });
 
-    test('should emit only one event when multiple events of same type are sent', async () => {
+    it('should emit only one event when multiple events of same type are sent', async () => {
       adapter['adapterState'].postState = jest.fn().mockResolvedValue(undefined);
       adapter.uploadAllRepos = jest.fn().mockResolvedValue(undefined);
 
@@ -571,7 +571,7 @@ describe(WorkerAdapter.name, () => {
       expect(counter.counter).toBe(1);
     });
 
-    test('should emit event when different event type is sent after previous events', async () => {
+    it('should emit event when different event type is sent after previous events', async () => {
       adapter['adapterState'].postState = jest.fn().mockResolvedValue(undefined);
       adapter.uploadAllRepos = jest.fn().mockResolvedValue(undefined);
 
@@ -590,11 +590,9 @@ describe(WorkerAdapter.name, () => {
       
       expect(counter.counter).toBe(1);
     });
-
-    test('should correctly emit one event even if postState errors', async () => {
-      adapter['adapterState'].postState = jest
-        .fn()
-        .mockRejectedValue(new Error('postState error'));
+     
+    it('should correctly emit one event even if postState errors', async () => {
+      adapter['adapterState'].postState = jest.fn().mockRejectedValue(new Error('postState error'));
       adapter.uploadAllRepos = jest.fn().mockResolvedValue(undefined);
 
       await adapter.emit(ExtractorEventType.ExtractionMetadataError, {
@@ -604,13 +602,9 @@ describe(WorkerAdapter.name, () => {
       expect(counter.counter).toBe(1);
     });
 
-    test('should correctly emit one event even if uploadAllRepos errors', async () => {
-      adapter['adapterState'].postState = jest
-        .fn()
-        .mockResolvedValue(undefined);
-      adapter.uploadAllRepos = jest
-        .fn()
-        .mockRejectedValue(new Error('uploadAllRepos error'));
+    it('should correctly emit one event even if uploadAllRepos errors', async () => {
+      adapter['adapterState'].postState = jest.fn().mockResolvedValue(undefined);
+      adapter.uploadAllRepos = jest.fn().mockRejectedValue(new Error('uploadAllRepos error'));
 
       await adapter.emit(ExtractorEventType.ExtractionMetadataError, {
         reports: [],

--- a/src/workers/worker-adapter.test.ts
+++ b/src/workers/worker-adapter.test.ts
@@ -80,7 +80,6 @@ describe(WorkerAdapter.name, () => {
 
   describe('streamAttachments', () => {
     it('should process all artifact batches successfully', async () => {
-      // Arrange
       const mockStream = jest.fn();
 
       // Set up adapter state with artifact IDs
@@ -129,7 +128,6 @@ describe(WorkerAdapter.name, () => {
         stream: mockStream,
       });
 
-      // Assert
       expect(adapter.initializeRepos).toHaveBeenCalledWith([
         { itemType: 'ssor_attachment' },
       ]);
@@ -148,9 +146,7 @@ describe(WorkerAdapter.name, () => {
 
     describe('[Edges]', () => {
       it('should handle invalid batch size by using 1 instead', async () => {
-        // Arrange
         const mockStream = jest.fn();
-        const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
 
         // Set up adapter state with artifact IDs
         adapter.state.toDevRev = {
@@ -170,27 +166,16 @@ describe(WorkerAdapter.name, () => {
 
         adapter.initializeRepos = jest.fn();
         
-        // Act
         const result = await adapter.streamAttachments({
           stream: mockStream,
           batchSize: 0,
         });
 
-        // Assert
-        expect(consoleWarnSpy).toHaveBeenCalledWith(
-          'The specified batch size (0) is invalid. Using 1 instead.'
-        );
-        
         expect(result).toBeUndefined();
-        
-        // Restore console.warn
-        consoleWarnSpy.mockRestore();
       });
 
       it('should cap batch size to 50 when batchSize is greater than 50', async () => {
-        // Arrange
         const mockStream = jest.fn();
-        const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
         
         // Set up adapter state with artifact IDs
         adapter.state.toDevRev = {
@@ -211,25 +196,15 @@ describe(WorkerAdapter.name, () => {
         // Mock the required methods
         adapter.initializeRepos = jest.fn();
       
-        // Act
         const result = await adapter.streamAttachments({
           stream: mockStream,
           batchSize: 100, // Set batch size greater than 50
         });
       
-        // Assert
-        expect(consoleWarnSpy).toHaveBeenCalledWith(
-          'The specified batch size (100) is too large. Using 50 instead.'
-        );
-        
         expect(result).toBeUndefined();
-        
-        // Restore console.warn
-        consoleWarnSpy.mockRestore();
       });
       
       it('should handle empty attachments metadata artifact IDs', async () => {
-        // Arrange
         const mockStream = jest.fn();
         
         // Set up adapter state with no artifact IDs
@@ -240,25 +215,14 @@ describe(WorkerAdapter.name, () => {
           },
         };
 
-        const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation();
-        
-        // Act
         const result = await adapter.streamAttachments({
           stream: mockStream,
         });
 
-        // Assert
-        expect(consoleLogSpy).toHaveBeenCalledWith(
-          'No attachments metadata artifact IDs found in state.'
-        );
         expect(result).toBeUndefined();
-        
-        // Restore console.log
-        consoleLogSpy.mockRestore();
       });
 
       it('should handle errors when getting attachments', async () => {
-        // Arrange
         const mockStream = jest.fn();
         
         // Set up adapter state with artifact IDs
@@ -278,25 +242,17 @@ describe(WorkerAdapter.name, () => {
 
         // Mock methods
         adapter.initializeRepos = jest.fn();
-        const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
         
-        // Act
         const result = await adapter.streamAttachments({
           stream: mockStream,
         });
 
-        // Assert
-        expect(consoleErrorSpy).toHaveBeenCalled();
         expect(result).toEqual({
           error: mockError,
         });
-        
-        // Restore console.error
-        consoleErrorSpy.mockRestore();
       });
 
       it('should handle empty attachments array from artifact', async () => {
-        // Arrange
         const mockStream = jest.fn();
         
         // Set up adapter state with artifact IDs
@@ -315,25 +271,17 @@ describe(WorkerAdapter.name, () => {
 
         // Mock methods
         adapter.initializeRepos = jest.fn();
-        const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
         
-        // Act
         const result = await adapter.streamAttachments({
           stream: mockStream,
         });
 
-        // Assert
-        expect(consoleWarnSpy).toHaveBeenCalled();
         expect(adapter.state.toDevRev.attachmentsMetadata.artifactIds).toEqual([]);
         expect(result).toBeUndefined();
-        
-        // Restore console.warn
-        consoleWarnSpy.mockRestore();
       });
     });
 
     it('should use custom processors when provided', async () => {
-      // Arrange
       const mockStream = jest.fn();
       const mockReducer = jest.fn().mockReturnValue(['custom-reduced']);
       const mockIterator = jest.fn().mockResolvedValue({});
@@ -356,9 +304,7 @@ describe(WorkerAdapter.name, () => {
 
       // Mock methods
       adapter.initializeRepos = jest.fn();
-      const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation();
-
-      // Act
+      
       const result = await adapter.streamAttachments({
         stream: mockStream,
         processors: {
@@ -367,7 +313,6 @@ describe(WorkerAdapter.name, () => {
         },
       });
 
-      // Assert
       expect(mockReducer).toHaveBeenCalledWith({
         attachments: [{ id: 'attachment1' }],
         adapter: adapter,
@@ -379,13 +324,9 @@ describe(WorkerAdapter.name, () => {
         stream: mockStream,
       });
       expect(result).toBeUndefined();
-
-      // Restore console.log
-      consoleLogSpy.mockRestore();
     });
 
     it('should handle rate limiting from iterator', async () => {
-      // Arrange
       const mockStream = jest.fn();
 
       (AttachmentsStreamingPool as jest.Mock).mockImplementationOnce(() => {
@@ -413,13 +354,11 @@ describe(WorkerAdapter.name, () => {
 
       // Mock methods
       adapter.initializeRepos = jest.fn();
-
-      // Act
+      
       const result = await adapter.streamAttachments({
         stream: mockStream,
       });
 
-      // Assert
       expect(result).toEqual({
         delay: 30,
       });
@@ -430,7 +369,6 @@ describe(WorkerAdapter.name, () => {
     });
 
     it('should handle error from iterator', async () => {
-      // Arrange
       const mockStream = jest.fn();
 
       (AttachmentsStreamingPool as jest.Mock).mockImplementationOnce(() => {
@@ -460,13 +398,11 @@ describe(WorkerAdapter.name, () => {
 
       // Mock methods
       adapter.initializeRepos = jest.fn();
-
-      // Act
+      
       const result = await adapter.streamAttachments({
         stream: mockStream,
       });
 
-      // Assert
       expect(result).toEqual({
         error: 'Mock error',
       });
@@ -533,7 +469,6 @@ describe(WorkerAdapter.name, () => {
       // Import the worker_threads module and spy on parentPort.postMessage
       const workerThreads = require('node:worker_threads');
       mockPostMessage = jest.fn().mockImplementation((a: any) => {
-        console.log('postMessage called with:', a);
         counter.counter += 1;
       });
 


### PR DESCRIPTION
## Summary
<!-- Provide a brief description of the story behind this PR, as if explaining
     to a non-technical person. Or to an LLM so it can learn from it for
     future (autonomous) code improvements. Feel free to point to a deeper
     design doc, if applicable.
-->
Updated tests to match the testing guidelines specified inside of CONTRIBUTING.md file.
I have changed how the testing works.

Before, we had `npm run test`, which ran all tests, including timeout tests, which took quite a while. I've removed them from the default testing and removed the coverage as well.

Full and coverage tests include timeout tests and can be accessed using `test:full` and `test:cov`. The actions should use `test:cov` by default and work as before.
This speeds up testing a lot (3.5s vs 26s).

## Connected Issues
<!-- Have you cared to connect this PR to a work item in DevRev, so that we
     can understand future routing and attribution?
-->
- [#ISS-202840](https://app.devrev.ai/devrev/works/ISS-202840) ([Needs to be merged before this, as it uses updated CONTRIBUTING.md](https://github.com/devrev/adaas-sdk/pull/61))
- [#ISS-202839](https://app.devrev.ai/devrev/works/ISS-202839)