### PR TITLE
Implement log tagging for SDK logs

### DIFF
--- a/src/attachments-streaming/attachments-streaming-pool.test.ts
+++ b/src/attachments-streaming/attachments-streaming-pool.test.ts
@@ -217,7 +217,7 @@ describe(AttachmentsStreamingPool.name, () => {
       await pool.streamAll();
 
       expect(console.warn).toHaveBeenCalledWith(
-        'Skipping attachment with ID attachment-2 due to error: Error: Processing failed'
+        "SDK: ", ["Skipping attachment with ID attachment-2 due to error: Error: Processing failed"]
       );
       expect(mockAdapter.state.toDevRev!.attachmentsMetadata.lastProcessedAttachmentsIdsList).toEqual([
         'attachment-1',

--- a/src/attachments-streaming/attachments-streaming-pool.ts
+++ b/src/attachments-streaming/attachments-streaming-pool.ts
@@ -5,6 +5,7 @@ import {
 } from '../types';
 import { AttachmentsStreamingPoolParams } from './attachments-streaming-pool.interfaces';
 import { WorkerAdapter } from '../workers/worker-adapter';
+import { sdkconsole as console } from 'sdkconsole';
 
 export class AttachmentsStreamingPool<ConnectorState> {
   private adapter: WorkerAdapter<ConnectorState>;

--- a/src/attachments-streaming/attachments-streaming-pool.ts
+++ b/src/attachments-streaming/attachments-streaming-pool.ts
@@ -5,7 +5,7 @@ import {
 } from '../types';
 import { AttachmentsStreamingPoolParams } from './attachments-streaming-pool.interfaces';
 import { WorkerAdapter } from '../workers/worker-adapter';
-import { sdkconsole as console } from 'sdkconsole';
+import { sdkconsole as console } from '../sdkconsole';
 
 export class AttachmentsStreamingPool<ConnectorState> {
   private adapter: WorkerAdapter<ConnectorState>;

--- a/src/common/helpers.ts
+++ b/src/common/helpers.ts
@@ -13,7 +13,7 @@ import {
 import { readFileSync } from 'fs';
 import * as path from 'path';
 import { MAX_DEVREV_FILENAME_EXTENSION_LENGTH, MAX_DEVREV_FILENAME_LENGTH } from './constants';
-import { sdkconsole as console } from 'sdkconsole';
+import { sdkconsole as console } from '../sdkconsole';
 
 export function getTimeoutErrorEventType(eventType: EventType): {
   eventType: ExtractorEventType | LoaderEventType;

--- a/src/common/helpers.ts
+++ b/src/common/helpers.ts
@@ -13,6 +13,7 @@ import {
 import { readFileSync } from 'fs';
 import * as path from 'path';
 import { MAX_DEVREV_FILENAME_EXTENSION_LENGTH, MAX_DEVREV_FILENAME_LENGTH } from './constants';
+import { sdkconsole as console } from 'sdkconsole';
 
 export function getTimeoutErrorEventType(eventType: EventType): {
   eventType: ExtractorEventType | LoaderEventType;

--- a/src/common/install-initial-domain-mapping.ts
+++ b/src/common/install-initial-domain-mapping.ts
@@ -4,7 +4,7 @@ import { AirdropEvent } from '../types/extraction';
 import { InitialDomainMapping } from '../types/common';
 import { serializeError } from '../logger/logger';
 
-import { sdkconsole as console } from 'sdkconsole';
+import { sdkconsole as console } from '../sdkconsole';
 
 export async function installInitialDomainMapping(
   event: AirdropEvent,

--- a/src/common/install-initial-domain-mapping.ts
+++ b/src/common/install-initial-domain-mapping.ts
@@ -4,6 +4,8 @@ import { AirdropEvent } from '../types/extraction';
 import { InitialDomainMapping } from '../types/common';
 import { serializeError } from '../logger/logger';
 
+import { sdkconsole as console } from 'sdkconsole';
+
 export async function installInitialDomainMapping(
   event: AirdropEvent,
   initialDomainMappingJson: InitialDomainMapping

--- a/src/http/axios-client-internal.ts
+++ b/src/http/axios-client-internal.ts
@@ -1,5 +1,6 @@
 import axios, { AxiosError } from 'axios';
 import axiosRetry from 'axios-retry';
+import { sdkconsole as console } from 'sdkconsole';
 
 const axiosClient = axios.create();
 

--- a/src/http/axios-client-internal.ts
+++ b/src/http/axios-client-internal.ts
@@ -1,6 +1,6 @@
 import axios, { AxiosError } from 'axios';
 import axiosRetry from 'axios-retry';
-import { sdkconsole as console } from 'sdkconsole';
+import { sdkconsole as console } from '../sdkconsole';
 
 const axiosClient = axios.create();
 

--- a/src/http/axios-client.ts
+++ b/src/http/axios-client.ts
@@ -25,7 +25,7 @@
 import axios, { AxiosError } from 'axios';
 import axiosRetry from 'axios-retry';
 
-import { sdkconsole as console } from 'sdkconsole';
+import { sdkconsole as console } from '../sdkconsole';
 
 const axiosClient = axios.create();
 

--- a/src/http/axios-client.ts
+++ b/src/http/axios-client.ts
@@ -25,6 +25,8 @@
 import axios, { AxiosError } from 'axios';
 import axiosRetry from 'axios-retry';
 
+import { sdkconsole as console } from 'sdkconsole';
+
 const axiosClient = axios.create();
 
 axiosRetry(axiosClient, {

--- a/src/repo/repo.ts
+++ b/src/repo/repo.ts
@@ -13,7 +13,7 @@ import {
   NormalizedAttachment,
 } from './repo.interfaces';
 import { WorkerAdapterOptions } from '../types/workers';
-import { sdkconsole as console } from 'sdkconsole';
+import { sdkconsole as console } from '../sdkconsole';
 
 export class Repo {
   readonly itemType: string;

--- a/src/repo/repo.ts
+++ b/src/repo/repo.ts
@@ -13,6 +13,7 @@ import {
   NormalizedAttachment,
 } from './repo.interfaces';
 import { WorkerAdapterOptions } from '../types/workers';
+import { sdkconsole as console } from 'sdkconsole';
 
 export class Repo {
   readonly itemType: string;

--- a/src/sdkconsole.ts
+++ b/src/sdkconsole.ts
@@ -1,0 +1,13 @@
+
+export class sdkconsole {
+    static warn(...args: any[]) {
+        console.warn("SDK: ", args);
+    }
+    static log(...args: any[]) {
+        console.log("SDK: ", args);
+    }
+
+    static error(...args: any[]) {
+        console.error("SDK: ", args);
+    }
+}

--- a/src/state/state.ts
+++ b/src/state/state.ts
@@ -15,6 +15,7 @@ import {
   SdkState,
   StateInterface,
 } from './state.interfaces';
+import { sdkconsole as console } from 'sdkconsole';
 
 export async function createAdapterState<ConnectorState>({
   event,

--- a/src/state/state.ts
+++ b/src/state/state.ts
@@ -15,7 +15,7 @@ import {
   SdkState,
   StateInterface,
 } from './state.interfaces';
-import { sdkconsole as console } from 'sdkconsole';
+import { sdkconsole as console } from '../sdkconsole';
 
 export async function createAdapterState<ConnectorState>({
   event,

--- a/src/uploader/uploader.ts
+++ b/src/uploader/uploader.ts
@@ -17,6 +17,7 @@ import {
 } from './uploader.interfaces';
 import { serializeError } from '../logger/logger';
 import { AxiosResponse } from 'axios';
+import { sdkconsole as console } from 'sdkconsole';
 
 export class Uploader {
   private event: AirdropEvent;

--- a/src/uploader/uploader.ts
+++ b/src/uploader/uploader.ts
@@ -17,7 +17,7 @@ import {
 } from './uploader.interfaces';
 import { serializeError } from '../logger/logger';
 import { AxiosResponse } from 'axios';
-import { sdkconsole as console } from 'sdkconsole';
+import { sdkconsole as console } from '../sdkconsole';
 
 export class Uploader {
   private event: AirdropEvent;

--- a/src/workers/default-workers/attachments-extraction.ts
+++ b/src/workers/default-workers/attachments-extraction.ts
@@ -9,6 +9,7 @@ import {
   serializeAxiosError,
 } from '../../index';
 import { axiosClient } from '../../http/axios-client-internal';
+import { sdkconsole as console } from 'sdkconsole';
 
 const getAttachmentStream = async ({
   item,

--- a/src/workers/default-workers/data-extraction.ts
+++ b/src/workers/default-workers/data-extraction.ts
@@ -5,7 +5,7 @@ import {
   normalizeIssue,
   normalizeUser,
 } from '../dummy-extractor/data-normalization';
-import { sdkconsole as console } from 'sdkconsole';
+import { sdkconsole as console } from '../../sdkconsole';
  
 // Dummy data that originally would be fetched from an external source
 const issues = [

--- a/src/workers/default-workers/data-extraction.ts
+++ b/src/workers/default-workers/data-extraction.ts
@@ -5,7 +5,8 @@ import {
   normalizeIssue,
   normalizeUser,
 } from '../dummy-extractor/data-normalization';
-
+import { sdkconsole as console } from 'sdkconsole';
+ 
 // Dummy data that originally would be fetched from an external source
 const issues = [
   {

--- a/src/workers/spawn.ts
+++ b/src/workers/spawn.ts
@@ -24,7 +24,7 @@ import {
   DEFAULT_LAMBDA_TIMEOUT,
   HARD_TIMEOUT_MULTIPLIER,
 } from '../common/constants';
-import { sdkconsole as console } from 'sdkconsole';
+import { sdkconsole as console } from '../sdkconsole';
 
 function getWorkerPath({
   event,

--- a/src/workers/spawn.ts
+++ b/src/workers/spawn.ts
@@ -24,6 +24,7 @@ import {
   DEFAULT_LAMBDA_TIMEOUT,
   HARD_TIMEOUT_MULTIPLIER,
 } from '../common/constants';
+import { sdkconsole as console } from 'sdkconsole';
 
 function getWorkerPath({
   event,

--- a/src/workers/worker-adapter.ts
+++ b/src/workers/worker-adapter.ts
@@ -45,7 +45,7 @@ import { Uploader } from '../uploader/uploader';
 import { serializeError } from '../logger/logger';
 import { SyncMapperRecordStatus } from '../mappers/mappers.interface';
 import { AttachmentsStreamingPool } from '../attachments-streaming/attachments-streaming-pool';
-import { sdkconsole as console } from 'sdkconsole';
+import { sdkconsole as console } from '../sdkconsole';
 
 export function createWorkerAdapter<ConnectorState>({
   event,

--- a/src/workers/worker-adapter.ts
+++ b/src/workers/worker-adapter.ts
@@ -44,8 +44,8 @@ import { Mappers } from '../mappers/mappers';
 import { Uploader } from '../uploader/uploader';
 import { serializeError } from '../logger/logger';
 import { SyncMapperRecordStatus } from '../mappers/mappers.interface';
-import { sleep } from '../common/helpers';
 import { AttachmentsStreamingPool } from '../attachments-streaming/attachments-streaming-pool';
+import { sdkconsole as console } from 'sdkconsole';
 
 export function createWorkerAdapter<ConnectorState>({
   event,


### PR DESCRIPTION
## Description
<!-- 
    A brief description of what the PR does/changes.
    Use active voice and present tense, e.g., This PR fixes ...
-->
This PR changes how the SDK internal logs are printed. As it currently stands, the SDK logs are all prefixed with `SDK: `.

## Connected Issues
<!--
    DevRev issue(s) full link(s) (e.g. https://app.devrev.ai/devrev/works/ISS-123).
-->
- [#ISS-202822](https://app.devrev.ai/devrev/works/ISS-202822)

## Checklist
- [x] Tests added/updated and ran with `npm run test` OR no tests needed.
- [x] Ran backwards compatibility tests with `npm run test:backwards-compatibility`.
<!-- Add this once we have eslint prepared:
- [ ] Code formatted and checked with `npm run lint`.
-->
- [x] no-docs
- [x] Tested airdrop-template linked to this PR.
