### PR TITLE
Mark progress field in `EventData` as deprecated

### DIFF
--- a/src/types/extraction.ts
+++ b/src/types/extraction.ts
@@ -211,6 +211,10 @@ export interface ConnectionData {
  */
 export interface EventData {
   external_sync_units?: ExternalSyncUnit[];
+  /**
+   * @deprecated This field is deprecated and should not be used. Progress is
+   * now calculated on the backend.
+   */
   progress?: number;
   error?: ErrorRecord;
   delay?: number;


### PR DESCRIPTION
## Description
<!-- 
    A brief description of what the PR does/changes.
    Use active voice and present tense, e.g., This PR fixes ...
-->
This PR marks the progress field in `EventData` interface as deprecated since progress will be calculated on backend and we will remove it from SDK.

## Connected Issues
<!--
    DevRev issue(s) full link(s) (e.g. https://app.devrev.ai/devrev/works/ISS-123).
-->
https://app.devrev.ai/devrev/works/ISS-210721

## Checklist
- [ ] Tests added/updated and ran with `npm run test` OR no tests needed.
<!-- Add this once we have backwards compatibility tests prepared:
- [ ] Ran backwards compatibility tests with `npm run test:backwards-compatibility`.
-->
<!-- Add this once we have eslint prepared:
- [ ] Code formatted and checked with `npm run lint`.
-->
- [ ] Documentation updated and provided a link to PR / new docs OR `no-docs` written.
- [ ] Tested airdrop-template linked to this PR.
