### PR TITLE
Fix ordering issue when artifacts exceed `batchSize`

### DIFF
--- a/src/repo/repo.ts
+++ b/src/repo/repo.ts
@@ -21,6 +21,7 @@ export class Repo {
   private uploader: Uploader;
   private onUpload: (artifact: Artifact) => void;
   private options?: WorkerAdapterOptions;
+  public uploadedArtifacts: Artifact[];
 
   constructor({
     event,
@@ -35,6 +36,7 @@ export class Repo {
     this.onUpload = onUpload;
     this.uploader = new Uploader({ event, options });
     this.options = options;
+    this.uploadedArtifacts = [];
   }
 
   getItems(): (NormalizedItem | NormalizedAttachment | Item)[] {
@@ -62,6 +64,8 @@ export class Repo {
       }
 
       this.onUpload(artifact);
+      
+      this.uploadedArtifacts.push(artifact);
 
       // Clear the uploaded items from the main items array if no batch was specified
       if (!batch) {

--- a/src/workers/worker-adapter.ordering.test.ts
+++ b/src/workers/worker-adapter.ordering.test.ts
@@ -1,0 +1,99 @@
+// 1. Create a mock function for the method you want to override.
+const mockUpload = (itemType: string, objects: object[]) => {
+  return {
+    error: null,
+    artifact: {
+      id: `artifact-${itemType}-${Math.random().toString(36).substring(2, 15)}`,
+      item_type: itemType,
+      item_count: objects.length,
+    }
+  };
+};
+
+// 2. Mock the entire 'uploader' module.
+// The factory function () => { ... } returns the mock implementation.
+jest.mock('../uploader/uploader', () => {
+  return {
+    // The mocked Uploader class
+    Uploader: jest.fn().mockImplementation(() => {
+      // The constructor of the mocked Uploader returns an object
+      // with the methods you want to control.
+      return {
+        upload: mockUpload,
+      };
+    }),
+  };
+});
+
+import { createEvent, createItems } from '../tests/test-helpers';
+import { WorkerAdapter } from "./worker-adapter";
+import { State, createAdapterState } from "../state/state";
+import { EventType } from "../types";
+
+describe("Batch ordering", () => {
+
+  describe('should take batch ordering into account', () => {
+    it('should maintain artifact ordering when repo A has items below batch size and repo B has items above batch size', async () => {
+      // Create a fresh adapter instance for this test to avoid mocking conflicts
+      interface TestState {
+        attachments: { completed: boolean };
+      }
+      let mockEvent = createEvent({ eventType: EventType.ExtractionDataStart });
+      let mockAdapterState = new State<TestState>({
+        event: mockEvent,
+        initialState: { attachments: { completed: false } },
+      });
+
+      const testAdapter = new WorkerAdapter({
+        event: mockEvent,
+        adapterState: mockAdapterState,
+        options: {
+          batchSize: 50
+        }
+      });
+
+      // Track the order of artifacts added to the adapter
+      const artifactOrder: string[] = [];
+      const originalArtifacts = testAdapter.artifacts;
+
+      // Override the artifacts setter to track order
+      Object.defineProperty(testAdapter, 'artifacts', {
+        get: () => originalArtifacts,
+        set: (artifacts) => {
+          // Track the order of artifacts being added
+          artifacts.forEach((artifact: any) => {
+            artifactOrder.push(artifact.item_type);
+          });
+          originalArtifacts.push(...artifacts);
+        }
+      });
+
+      // Initialize repos
+      testAdapter.initializeRepos([
+        { itemType: 'A' },
+        { itemType: 'B' }
+      ]);
+
+      await testAdapter.getRepo('A')?.push(createItems(5));
+      await testAdapter.getRepo('B')?.push(createItems(105));
+
+      await testAdapter.uploadAllRepos();
+
+      const artifacts = testAdapter.artifacts;
+      console.log(artifacts);
+      expect(artifacts.length).toBe(4);
+
+      // Check that all 'A' artifacts come before any 'B' artifacts
+      let firstBFound = false;
+      for (const artifact of artifacts) {
+        if (artifact.item_type === 'B') {
+          firstBFound = true;
+        } else if (artifact.item_type === 'A') {
+          // If we find an 'A' artifact after we've already found a 'B' artifact,
+          // the ordering is incorrect
+          expect(firstBFound).toBe(false);
+        }
+      }
+    });
+  });
+});

--- a/src/workers/worker-adapter.ts
+++ b/src/workers/worker-adapter.ts
@@ -147,8 +147,6 @@ export class WorkerAdapter<ConnectorState> {
         itemType: repo.itemType,
         ...(shouldNormalize && { normalize: repo.normalize }),
         onUpload: (artifact: Artifact) => {
-          this.artifacts.push(artifact);
-
           // We need to store artifacts ids in state for later use when streaming attachments
           if (repo.itemType === AIRDROP_DEFAULT_ITEM_TYPES.ATTACHMENTS) {
             this.state.toDevRev?.attachmentsMetadata.artifactIds.push(
@@ -274,6 +272,7 @@ export class WorkerAdapter<ConnectorState> {
   async uploadAllRepos(): Promise<void> {
     for (const repo of this.repos) {
       const error = await repo.upload();
+      this.artifacts.push(...repo.uploadedArtifacts);
       if (error) {
         throw error;
       }


### PR DESCRIPTION
## Description

<!--
    A brief description of what the PR does/changes.
    Use active voice and present tense, e.g., This PR fixes ...
-->
This PR fixes the issue that occurred when the amount of the items was larger than the batch size, which made the artifacts upload, but returned the artifact list ordered according to the upload time, not the repository order.
## Connected Issues

<!--
    DevRev issue(s) full link(s) (e.g. https://app.devrev.ai/devrev/works/ISS-123).
-->
- [#ISS-212974](https://app.devrev.ai/devrev/works/ISS-212974)

## Checklist

- [x] Tests added/updated and ran with `npm run test` OR no tests needed.
- [x] Ran backwards compatibility tests with `npm run test:backwards-compatibility`.
- [ ] Tested airdrop-template linked to this PR.
- [x] Documentation updated and provided a link to PR / new docs OR `no-docs` written: `no-docs`
<!-- Add this once we have eslint prepared:
- [ ] Code formatted and checked with `npm run lint`. -->
