### PR TITLE
Check adapter.isTimeout when streaming attachments in parallel and improve logging

### DIFF
--- a/src/attachments-streaming/attachments-streaming-pool.ts
+++ b/src/attachments-streaming/attachments-streaming-pool.ts
@@ -1,7 +1,7 @@
 import {
   NormalizedAttachment,
   ExternalSystemAttachmentStreamingFunction,
-  ProcessAttachmentReturnType
+  ProcessAttachmentReturnType,
 } from '../types';
 import { AttachmentsStreamingPoolParams } from './attachments-streaming-pool.interfaces';
 import { WorkerAdapter } from '../workers/worker-adapter';
@@ -68,9 +68,19 @@ export class AttachmentsStreamingPool<ConnectorState> {
   async startPoolStreaming() {
     // Process attachments until the attachments array is empty
     while (this.attachments.length > 0) {
+      // If delay is set, stop streaming
       if (this.delay) {
-        break; // Exit if we have a delay
+        break;
       }
+
+      // If timeout is set, stop streaming
+      if (this.adapter.isTimeout) {
+        console.log(
+          'Timeout deteceted while streaming attachments. Stopping streaming.'
+        );
+        break;
+      }
+
       // Check if we can process next attachment
       const attachment = this.attachments.shift();
 
@@ -110,7 +120,6 @@ export class AttachmentsStreamingPool<ConnectorState> {
           this.adapter.state.toDevRev?.attachmentsMetadata.lastProcessedAttachmentsIdsList.push(
             attachment.id
           );
-          console.log(`Successfully processed attachment: ${attachment.id}`);
         }
       } catch (error) {
         console.warn(

--- a/src/http/axios-client-internal.ts
+++ b/src/http/axios-client-internal.ts
@@ -1,7 +1,9 @@
 import axios, { AxiosError } from 'axios';
 import axiosRetry from 'axios-retry';
 
-const axiosClient = axios.create();
+const axiosClient = axios.create({
+  timeout: 30 * 1000,
+});
 
 axiosRetry(axiosClient, {
   retries: 5,

--- a/src/workers/process-task.ts
+++ b/src/workers/process-task.ts
@@ -33,8 +33,16 @@ export function processTask<ConnectorState>({
 
         parentPort.on(WorkerEvent.WorkerMessage, async (message) => {
           if (message.subject === WorkerMessageSubject.WorkerMessageExit) {
+            console.log(
+              'Worker received message to gracefully exit. Setting isTimeout flag and executing onTimeout function.'
+            );
+
             adapter.handleTimeout();
             await onTimeout({ adapter });
+
+            console.log(
+              'Finished executing onTimeout function. Exiting worker.'
+            );
             process.exit(0);
           }
         });

--- a/src/workers/spawn.ts
+++ b/src/workers/spawn.ts
@@ -195,7 +195,7 @@ export class Spawn {
 
     // If hard timeout is reached, that means the worker did not exit in time. Terminate the worker.
     this.hardTimeoutTimer = setTimeout(async () => {
-      this.logger.log(
+      this.logger.error(
         'HARD TIMEOUT: Worker did not exit in time. Terminating the worker.'
       );
       if (worker) {

--- a/src/workers/worker-adapter.ts
+++ b/src/workers/worker-adapter.ts
@@ -205,6 +205,10 @@ export class WorkerAdapter<ConnectorState> {
 
     // We want to upload all the repos before emitting the event, except for the external sync units done event
     if (newEventType !== ExtractorEventType.ExtractionExternalSyncUnitsDone) {
+      console.log(
+        `Uploading all repos before emitting event with event type: ${newEventType}.`
+      );
+
       try {
         await this.uploadAllRepos();
       } catch (error) {
@@ -220,6 +224,7 @@ export class WorkerAdapter<ConnectorState> {
       console.log(
         `Overwriting lastSuccessfulSyncStarted with lastSyncStarted (${this.state.lastSyncStarted}).`
       );
+
       this.state.lastSuccessfulSyncStarted = this.state.lastSyncStarted;
       this.state.lastSyncStarted = '';
     }
@@ -703,6 +708,13 @@ export class WorkerAdapter<ConnectorState> {
       if (!preparedArtifact) {
         console.warn(
           `Error while preparing artifact for attachment ID ${attachment.id}. Skipping attachment.`
+        );
+        return;
+      }
+
+      if (this.isTimeout) {
+        console.log(
+          'Timeout detected while processing attachment. Stopping streaming.'
         );
         return;
       }


### PR DESCRIPTION
## Description

<!--
    A brief description of what the PR does/changes.
    Use active voice and present tense, e.g., This PR fixes ...
-->
This PR checks if soft timeout when streaming attachments using streaming attachments pool and improves logging.

## Connected Issues

<!--
    DevRev issue(s) full link(s) (e.g. https://app.devrev.ai/devrev/works/ISS-123).
-->
https://app.devrev.ai/devrev/works/ISS-211818

## Checklist

- [x] Tests added/updated and ran with `npm run test` OR no tests needed.
- [x] Ran backwards compatibility tests with `npm run test:backwards-compatibility`.
- [x] Tested airdrop-template linked to this PR.
- [x] Documentation updated and provided a link to PR / new docs OR `no-docs` written: no docs
<!-- Add this once we have eslint prepared:
- [ ] Code formatted and checked with `npm run lint`. -->
