### PR TITLE
Destroy http stream in case of file is too big or failure happens

### DIFF
--- a/src/uploader/uploader.ts
+++ b/src/uploader/uploader.ts
@@ -167,6 +167,7 @@ export class Uploader {
       console.warn(
         `File size exceeds the maximum limit of ${MAX_DEVREV_ARTIFACT_SIZE} bytes.`
       );
+      this.destroyStream(fileStream);
       return;
     }
 
@@ -186,6 +187,7 @@ export class Uploader {
       return response;
     } catch (error) {
       console.error('Error while streaming artifact.', serializeError(error));
+      this.destroyStream(fileStream);
       return;
     }
   }
@@ -213,6 +215,25 @@ export class Uploader {
         'Error while confirming artifact upload.',
         serializeError(error)
       );
+    }
+  }
+
+  /**
+   * Destroys a stream to prevent resource leaks.
+   * @param {any} fileStream - The axios response stream to destroy
+   */
+  private destroyStream(fileStream: any): void {
+    try {
+      if (fileStream && fileStream.data) {
+        // For axios response streams, the data property contains the actual stream
+        if (typeof fileStream.data.destroy === 'function') {
+          fileStream.data.destroy();
+        } else if (typeof fileStream.data.close === 'function') {
+          fileStream.data.close();
+        }
+      }
+    } catch (error) {
+      console.warn('Error while destroying stream:', serializeError(error));
     }
   }
 


### PR DESCRIPTION
## Description

<!--
    A brief description of what the PR does/changes.
    Use active voice and present tense, e.g., This PR fixes ...
-->
This PR adds handling for destroying http streams (or closing it) when file is too big or if failure happens.

## Connected Issues

<!--
    DevRev issue(s) full link(s) (e.g. https://app.devrev.ai/devrev/works/ISS-123).
-->
https://app.devrev.ai/devrev/works/ISS-214092

## Checklist

- [x] Tests added/updated and ran with `npm run test` OR no tests needed.
- [x] Ran backwards compatibility tests with `npm run test:backwards-compatibility`.
- [x] Tested airdrop-template linked to this PR.
- [x] Documentation updated and provided a link to PR / new docs OR `no-docs` written:
<!-- Add this once we have eslint prepared:
- [ ] Code formatted and checked with `npm run lint`. -->
