### PR TITLE
Add memory logs and destroy stream on successful case

### DIFF
--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -69,5 +69,6 @@ export const LIBRARY_VERSION = getLibraryVersion();
 
 export const DEFAULT_LAMBDA_TIMEOUT = 10 * 60 * 1000; // 10 minutes
 export const HARD_TIMEOUT_MULTIPLIER = 1.3;
+export const MEMORY_LOG_INTERVAL = 10 * 1000; // 10 seconds
 
 export const DEFAULT_SLEEP_DELAY_MS = 3 * 60 * 1000; // 3 minutes

--- a/src/uploader/uploader.ts
+++ b/src/uploader/uploader.ts
@@ -184,6 +184,7 @@ export class Uploader {
         maxRedirects: 0, // Prevents buffering
         validateStatus: () => true, // Prevents errors on redirects
       });
+      this.destroyStream(fileStream);
       return response;
     } catch (error) {
       console.error('Error while streaming artifact.', serializeError(error));

--- a/src/workers/worker-adapter.ts
+++ b/src/workers/worker-adapter.ts
@@ -727,6 +727,7 @@ export class WorkerAdapter<ConnectorState> {
         console.warn(
           `Error while streaming to artifact for attachment ID ${attachment.id}. Skipping attachment.`
         );
+        this.destroyHttpStream(httpStream);
         return;
       }
 


### PR DESCRIPTION
## Description

<!--
    A brief description of what the PR does/changes.
    Use active voice and present tense, e.g., This PR fixes ...
-->
This PR adds few more safety http stream destroys and adds memory logging every 10 seconds in main thread.

## Connected Issues
- https://app.devrev.ai/devrev/works/ISS-214557
- https://app.devrev.ai/devrev/works/ISS-214092


## Checklist

- [x] Tests added/updated and ran with `npm run test` OR no tests needed.
- [x] Ran backwards compatibility tests with `npm run test:backwards-compatibility`.
- [x] Tested airdrop-template linked to this PR.
- [x] Documentation updated and provided a link to PR / new docs OR `no-docs` written:
<!-- Add this once we have eslint prepared:
- [ ] Code formatted and checked with `npm run lint`. -->
