### PR TITLE
Don't update progress for already processed attachments, default worker

### DIFF
--- a/src/attachments-streaming/attachments-streaming-pool.ts
+++ b/src/attachments-streaming/attachments-streaming-pool.ts
@@ -104,7 +104,6 @@ export class AttachmentsStreamingPool<ConnectorState> {
           attachment.id
         )
       ) {
-        this.updateProgress();
         continue; // Skip if the attachment ID is already processed
       }
 


### PR DESCRIPTION
## Description

<!--
    A brief description of what the PR does/changes.
    Use active voice and present tense, e.g., This PR fixes ...
-->
This PR removes progress update for already processed attachments and fixes default worker.

## Connected Issues

<!--
    DevRev issue(s) full link(s) (e.g. https://app.devrev.ai/devrev/works/ISS-123).
-->
https://app.devrev.ai/devrev/works/ISS-214092

## Checklist

- [x] Tests added/updated and ran with `npm run test` OR no tests needed.
- [x] Ran backwards compatibility tests with `npm run test:backwards-compatibility`.
- [x] Tested airdrop-template linked to this PR.
- [x] Documentation updated and provided a link to PR / new docs OR `no-docs` written:
<!-- Add this once we have eslint prepared:
- [ ] Code formatted and checked with `npm run lint`. -->
