### PR TITLE
Add short delay to attachment streaming pool, remove redundant logs and take error from processAttachment into count

### DIFF
--- a/src/common/helpers.ts
+++ b/src/common/helpers.ts
@@ -202,7 +202,7 @@ export function getLibraryVersion() {
 }
 
 export function sleep(ms: number) {
-  console.log(`Sleeping for ${ms}ms.`);
+  console.log(`Sleeping for ${ms / 1000}s.`);
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 

--- a/src/workers/worker-adapter.ts
+++ b/src/workers/worker-adapter.ts
@@ -688,7 +688,6 @@ export class WorkerAdapter<ConnectorState> {
     });
 
     if (error) {
-      console.warn('Error while streaming attachment', error);
       return { error };
     } else if (delay) {
       return { delay };


### PR DESCRIPTION
## Description

<!--
    A brief description of what the PR does/changes.
    Use active voice and present tense, e.g., This PR fixes ...
-->
This PR adds short delay when streaming attachments, removes redundant logs and takes error from processAttachment into count.

## Connected Issues

<!--
    DevRev issue(s) full link(s) (e.g. https://app.devrev.ai/devrev/works/ISS-123).
-->
https://app.devrev.ai/devrev/works/ISS-214092

## Checklist

- [x] Tests added/updated and ran with `npm run test` OR no tests needed.
- [x] Ran backwards compatibility tests with `npm run test:backwards-compatibility`.
- [x] Tested airdrop-template linked to this PR.
- [x] Documentation updated and provided a link to PR / new docs OR `no-docs` written:
<!-- Add this once we have eslint prepared:
- [ ] Code formatted and checked with `npm run lint`. -->
