### PR TITLE
Prevent push to repos, state updates and emits from worker when timeout is active

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@devrev/ts-adaas",
-  "version": "1.15.2",
+  "version": "1.15.3-beta.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@devrev/ts-adaas",
-      "version": "1.15.2",
+      "version": "1.15.3-beta.0",
       "license": "ISC",
       "dependencies": {
         "@devrev/typescript-sdk": "^1.1.59",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@devrev/ts-adaas",
-  "version": "1.15.2",
+  "version": "1.15.3-beta.0",
   "description": "Typescript library containing the ADaaS(AirDrop as a Service) control protocol.",
   "type": "commonjs",
   "main": "./dist/index.js",

--- a/src/common/read-only-proxy.test.ts
+++ b/src/common/read-only-proxy.test.ts
@@ -1,0 +1,160 @@
+import { createReadOnlyProxy } from './read-only-proxy';
+
+describe('createReadOnlyProxy', () => {
+  let consoleWarnSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
+  });
+
+  afterEach(() => {
+    consoleWarnSpy.mockRestore();
+  });
+
+  it('should allow reading properties', () => {
+    const original = { foo: 'bar', nested: { value: 123 } };
+    const proxy = createReadOnlyProxy(original);
+
+    expect(proxy.foo).toBe('bar');
+    expect(proxy.nested.value).toBe(123);
+  });
+
+  it('should prevent direct property modification', () => {
+    const original = { foo: 'bar' };
+    const proxy = createReadOnlyProxy(original);
+
+    proxy.foo = 'baz';
+
+    expect(original.foo).toBe('bar');
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Attempted to modify state.foo during timeout')
+    );
+  });
+
+  it('should prevent nested property modification', () => {
+    const original = { nested: { value: 123 } };
+    const proxy = createReadOnlyProxy(original);
+
+    proxy.nested.value = 456;
+
+    expect(original.nested.value).toBe(123);
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'Attempted to modify state.nested.value during timeout'
+      )
+    );
+  });
+
+  it('should prevent array mutations via push', () => {
+    const original = { items: [1, 2, 3] };
+    const proxy = createReadOnlyProxy(original);
+
+    proxy.items.push(4);
+
+    expect(original.items).toEqual([1, 2, 3]);
+    expect(consoleWarnSpy).toHaveBeenCalled();
+  });
+
+  it('should prevent array index assignment', () => {
+    const original = { items: [1, 2, 3] };
+    const proxy = createReadOnlyProxy(original);
+
+    proxy.items[0] = 999;
+
+    expect(original.items[0]).toBe(1);
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Attempted to modify state.items.0 during timeout')
+    );
+  });
+
+  it('should prevent property deletion', () => {
+    const original: { foo?: string } = { foo: 'bar' };
+    const proxy = createReadOnlyProxy(original);
+
+    delete proxy.foo;
+
+    expect(original.foo).toBe('bar');
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Attempted to delete state.foo during timeout')
+    );
+  });
+
+  it('should prevent adding new properties', () => {
+    const original: { foo: string; bar?: string } = { foo: 'bar' };
+    const proxy = createReadOnlyProxy(original);
+
+    proxy.bar = 'baz';
+
+    expect(original.bar).toBeUndefined();
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Attempted to modify state.bar during timeout')
+    );
+  });
+
+  it('should handle deeply nested objects', () => {
+    const original = {
+      level1: {
+        level2: {
+          level3: {
+            value: 'deep',
+          },
+        },
+      },
+    };
+    const proxy = createReadOnlyProxy(original);
+
+    proxy.level1.level2.level3.value = 'modified';
+
+    expect(original.level1.level2.level3.value).toBe('deep');
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'Attempted to modify state.level1.level2.level3.value during timeout'
+      )
+    );
+  });
+
+  it('should use custom path in warning messages', () => {
+    const original = { foo: 'bar' };
+    const proxy = createReadOnlyProxy(original, 'adapter.state');
+
+    proxy.foo = 'baz';
+
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Attempted to modify adapter.state.foo')
+    );
+  });
+
+  it('should return the same proxy for the same nested object', () => {
+    const original = { nested: { value: 123 } };
+    const proxy = createReadOnlyProxy(original);
+
+    const nested1 = proxy.nested;
+    const nested2 = proxy.nested;
+
+    expect(nested1).toBe(nested2);
+  });
+
+  it('should handle null values in nested objects', () => {
+    const original: { nested: { value: string | null } } = {
+      nested: { value: null },
+    };
+    const proxy = createReadOnlyProxy(original);
+
+    expect(proxy.nested.value).toBeNull();
+  });
+
+  it('should handle primitive return values correctly', () => {
+    const original = {
+      string: 'hello',
+      number: 42,
+      boolean: true,
+      undefined: undefined,
+    };
+    const proxy = createReadOnlyProxy(original);
+
+    expect(proxy.string).toBe('hello');
+    expect(proxy.number).toBe(42);
+    expect(proxy.boolean).toBe(true);
+    expect(proxy.undefined).toBeUndefined();
+  });
+});

--- a/src/common/read-only-proxy.ts
+++ b/src/common/read-only-proxy.ts
@@ -1,0 +1,70 @@
+/**
+ * Creates a deep read-only proxy that prevents mutations to an object and its nested properties.
+ * When a mutation is attempted, it logs a warning and ignores the mutation.
+ *
+ * @param target - The object to wrap in a read-only proxy
+ * @param path - The current property path (used for warning messages)
+ * @returns A proxy that prevents mutations
+ */
+export function createReadOnlyProxy<T extends object>(
+  target: T,
+  path: string = 'state'
+): T {
+  const proxyCache = new WeakMap<object, object>();
+
+  function createProxy<O extends object>(obj: O, currentPath: string): O {
+    if (obj === null || typeof obj !== 'object') {
+      return obj;
+    }
+
+    const cached = proxyCache.get(obj);
+    if (cached) {
+      return cached as O;
+    }
+
+    const proxy = new Proxy(obj, {
+      get(target, prop, receiver) {
+        const value = Reflect.get(target, prop, receiver);
+
+        if (typeof prop === 'symbol') {
+          return value;
+        }
+
+        if (value !== null && typeof value === 'object') {
+          return createProxy(value, `${currentPath}.${String(prop)}`);
+        }
+
+        return value;
+      },
+
+      set(_target, prop, _value) {
+        console.warn(
+          `Attempted to modify ${currentPath}.${String(prop)} during timeout. ` +
+            `State modifications are not allowed after timeout is triggered.`
+        );
+        return true;
+      },
+
+      deleteProperty(_target, prop) {
+        console.warn(
+          `Attempted to delete ${currentPath}.${String(prop)} during timeout. ` +
+            `State modifications are not allowed after timeout is triggered.`
+        );
+        return true;
+      },
+
+      defineProperty(_target, prop, _descriptor) {
+        console.warn(
+          `Attempted to define ${currentPath}.${String(prop)} during timeout. ` +
+            `State modifications are not allowed after timeout is triggered.`
+        );
+        return true;
+      },
+    });
+
+    proxyCache.set(obj, proxy);
+    return proxy;
+  }
+
+  return createProxy(target, path);
+}

--- a/src/multithreading/worker-adapter/worker-adapter.ts
+++ b/src/multithreading/worker-adapter/worker-adapter.ts
@@ -184,6 +184,7 @@ export class WorkerAdapter<ConnectorState> {
 
   async postState() {
     return runWithSdkLogContext(async () => {
+      if (this.isTimeout) return;
       await this.adapterState.postState();
     });
   }
@@ -210,6 +211,8 @@ export class WorkerAdapter<ConnectorState> {
   ): Promise<void> {
     return runWithSdkLogContext(async () => {
       newEventType = translateOutgoingEventType(newEventType);
+
+      if (this.isTimeout) return;
 
       if (this.hasWorkerEmitted) {
         console.warn(
@@ -304,6 +307,9 @@ export class WorkerAdapter<ConnectorState> {
 
   handleTimeout() {
     this.isTimeout = true;
+    for (const repo of this.repos) {
+      repo.lock();
+    }
   }
 
   async loadItemTypes({

--- a/src/multithreading/worker-adapter/worker-adapter.ts
+++ b/src/multithreading/worker-adapter/worker-adapter.ts
@@ -7,6 +7,7 @@ import {
   STATELESS_EVENT_TYPES,
 } from '../../common/constants';
 import { emit } from '../../common/control-protocol';
+import { createReadOnlyProxy } from '../../common/read-only-proxy';
 import {
   addReportToLoaderReport,
   getFilesToLoad,
@@ -125,6 +126,9 @@ export class WorkerAdapter<ConnectorState> {
   }
 
   get state(): AdapterState<ConnectorState> {
+    if (this.isTimeout) {
+      return createReadOnlyProxy(this.adapterState.state);
+    }
     return this.adapterState.state;
   }
 

--- a/src/repo/repo.ts
+++ b/src/repo/repo.ts
@@ -22,6 +22,7 @@ export class Repo {
   private onUpload: (artifact: Artifact) => void;
   private options?: WorkerAdapterOptions;
   public uploadedArtifacts: Artifact[];
+  private locked = false;
 
   constructor({
     event,
@@ -41,6 +42,10 @@ export class Repo {
 
   getItems(): (NormalizedItem | NormalizedAttachment | Item)[] {
     return this.items;
+  }
+
+  lock() {
+    this.locked = true;
   }
 
   async upload(
@@ -83,6 +88,10 @@ export class Repo {
   }
 
   async push(items: Item[]): Promise<boolean> {
+    if (this.locked) {
+      return true;
+    }
+
     let recordsToPush: (NormalizedItem | NormalizedAttachment | Item)[];
 
     if (!items || items.length === 0) {


### PR DESCRIPTION
## Description
<!--
    A brief description of what the PR does/changes.
    Use active voice and present tense, e.g., This PR fixes ...
-->
This PR adds guards for pushing to repos, state updates and emits if timeout is active.

## Connected Issues
<!--
    DevRev issue(s) full link(s) (e.g. https://app.devrev.ai/devrev/works/ISS-123).
-->
https://app.devrev.ai/devrev/works/ISS-262861

## Checklist
- [x] Tests added/updated and ran with `npm run test` OR no tests needed.
- [x] Ran backwards compatibility tests with `npm run test:backwards-compatibility`.
- [x] Code formatted and checked with `npm run lint`.
- [x] Tested airdrop-template linked to this PR.
- [x] Documentation updated and provided a link to PR / new docs OR no docs needed.
