### PR TITLE
Add local URL check and remove exponential backoff for unreachable endpoints

### DIFF
--- a/src/attachments-streaming/attachments-streaming-pool.test.ts
+++ b/src/attachments-streaming/attachments-streaming-pool.test.ts
@@ -461,9 +461,9 @@ describe(AttachmentsStreamingPool.name, () => {
         attachmentWithContentType,
         mockStream
       );
-      expect(
-        mockAdapter.processAttachment.mock.calls[0][0].content_type
-      ).toBe('application/pdf');
+      expect(mockAdapter.processAttachment.mock.calls[0][0].content_type).toBe(
+        'application/pdf'
+      );
     });
 
     it('should handle mixed attachments with and without content_type', async () => {
@@ -502,15 +502,15 @@ describe(AttachmentsStreamingPool.name, () => {
       await pool.streamAll();
 
       expect(mockAdapter.processAttachment).toHaveBeenCalledTimes(3);
-      expect(
-        mockAdapter.processAttachment.mock.calls[0][0].content_type
-      ).toBe('image/png');
+      expect(mockAdapter.processAttachment.mock.calls[0][0].content_type).toBe(
+        'image/png'
+      );
       expect(
         mockAdapter.processAttachment.mock.calls[1][0].content_type
       ).toBeUndefined();
-      expect(
-        mockAdapter.processAttachment.mock.calls[2][0].content_type
-      ).toBe('application/pdf');
+      expect(mockAdapter.processAttachment.mock.calls[2][0].content_type).toBe(
+        'application/pdf'
+      );
     });
 
     it('should include content_type in error log when processAttachment returns error', async () => {

--- a/src/http/axios-client.test.ts
+++ b/src/http/axios-client.test.ts
@@ -140,6 +140,40 @@ describe('isLocalUrl', () => {
         true
       );
     });
+
+    it('169.254.0.1 (link-local)', () => {
+      expect(isLocalUrl('http://169.254.0.1')).toBe(true);
+    });
+
+    it('169.254.169.254 (cloud metadata endpoint)', () => {
+      expect(isLocalUrl('http://169.254.169.254/latest/meta-data')).toBe(true);
+    });
+
+    it('169.254.255.255 (end of link-local range)', () => {
+      expect(isLocalUrl('http://169.254.255.255')).toBe(true);
+    });
+
+    it('[fe80::1] (IPv6 link-local)', () => {
+      expect(isLocalUrl('http://[fe80::1]')).toBe(true);
+    });
+
+    it('[fe80::1%25eth0] (IPv6 link-local with zone ID — unparseable, fails open)', () => {
+      // URL parser throws on zone IDs, so isLocalUrl fails open (returns false).
+      // This is acceptable since zone-scoped IPv6 URLs are not realistic customer input.
+      expect(isLocalUrl('http://[fe80::1%25eth0]')).toBe(false);
+    });
+
+    it('[fd00::1] (IPv6 unique-local)', () => {
+      expect(isLocalUrl('http://[fd00::1]')).toBe(true);
+    });
+
+    it('[fd12:3456:789a::1] (IPv6 unique-local with prefix)', () => {
+      expect(isLocalUrl('http://[fd12:3456:789a::1]/files')).toBe(true);
+    });
+
+    it('[fc00::1] (IPv6 unique-local fc00 prefix)', () => {
+      expect(isLocalUrl('http://[fc00::1]')).toBe(true);
+    });
   });
 
   describe('should return false for public/external URLs', () => {
@@ -179,6 +213,14 @@ describe('isLocalUrl', () => {
 
     it('172.32.0.1 (above private range)', () => {
       expect(isLocalUrl('http://172.32.0.1')).toBe(false);
+    });
+
+    it('169.253.0.1 (not in link-local range)', () => {
+      expect(isLocalUrl('http://169.253.0.1')).toBe(false);
+    });
+
+    it('169.255.0.1 (not in link-local range)', () => {
+      expect(isLocalUrl('http://169.255.0.1')).toBe(false);
     });
 
     it('11.0.0.1 (not in 10.x range)', () => {
@@ -379,5 +421,34 @@ describe('axiosClient retryCondition integration', () => {
 
     expect(isLocalUrl(error.config?.url)).toBe(false);
     expect(isNonRetryableConnectionError(error)).toBe(false);
+  });
+
+  it('should not retry any error to a link-local IP (cloud metadata)', () => {
+    const error = createAxiosError({
+      code: 'ECONNRESET',
+      url: 'http://169.254.169.254/latest/meta-data',
+    });
+
+    // ECONNRESET is normally retryable, but the URL is link-local
+    expect(isLocalUrl(error.config?.url)).toBe(true);
+  });
+
+  it('should not retry any error to an IPv6 link-local address', () => {
+    const error = createAxiosError({
+      code: 'ECONNREFUSED',
+      url: 'http://[fe80::1]:8080/files',
+    });
+
+    expect(isLocalUrl(error.config?.url)).toBe(true);
+    expect(isNonRetryableConnectionError(error)).toBe(true);
+  });
+
+  it('should not retry any error to an IPv6 unique-local address', () => {
+    const error = createAxiosError({
+      code: 'ETIMEDOUT',
+      url: 'http://[fd00::1]:3000/attachments',
+    });
+
+    expect(isLocalUrl(error.config?.url)).toBe(true);
   });
 });

--- a/src/http/axios-client.test.ts
+++ b/src/http/axios-client.test.ts
@@ -1,0 +1,383 @@
+import { AxiosError, AxiosHeaders } from 'axios';
+import { isLocalUrl, isNonRetryableConnectionError } from './axios-client';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+/**
+ * Helper to create a minimal AxiosError with a specific error code and optional URL.
+ */
+function createAxiosError({
+  code,
+  url,
+  status,
+}: {
+  code?: string;
+  url?: string;
+  status?: number;
+}): AxiosError {
+  const error = new AxiosError(
+    'Request failed',
+    code,
+    {
+      url,
+      headers: new AxiosHeaders(),
+    } as any,
+    undefined,
+    status
+      ? ({
+          status,
+          statusText: 'Error',
+          headers: {},
+          config: {} as any,
+          data: {},
+        } as any)
+      : undefined
+  );
+
+  return error;
+}
+
+describe('isLocalUrl', () => {
+  describe('should return true for local/private URLs', () => {
+    it('localhost', () => {
+      expect(isLocalUrl('http://localhost')).toBe(true);
+    });
+
+    it('localhost with port', () => {
+      expect(isLocalUrl('http://localhost:8080')).toBe(true);
+    });
+
+    it('localhost with path', () => {
+      expect(isLocalUrl('http://localhost:3000/api/v1/files/123')).toBe(true);
+    });
+
+    it('localhost HTTPS', () => {
+      expect(isLocalUrl('https://localhost/file.pdf')).toBe(true);
+    });
+
+    it('0.0.0.0', () => {
+      expect(isLocalUrl('http://0.0.0.0')).toBe(true);
+    });
+
+    it('0.0.0.0 with port', () => {
+      expect(isLocalUrl('http://0.0.0.0:9090/files')).toBe(true);
+    });
+
+    it('127.0.0.1 (IPv4 loopback)', () => {
+      expect(isLocalUrl('http://127.0.0.1')).toBe(true);
+    });
+
+    it('127.0.0.1 with port', () => {
+      expect(isLocalUrl('http://127.0.0.1:3000')).toBe(true);
+    });
+
+    it('127.0.0.255 (other loopback address)', () => {
+      expect(isLocalUrl('http://127.0.0.255')).toBe(true);
+    });
+
+    it('127.255.255.255 (end of loopback range)', () => {
+      expect(isLocalUrl('http://127.255.255.255')).toBe(true);
+    });
+
+    it('[::1] (IPv6 loopback)', () => {
+      expect(isLocalUrl('http://[::1]')).toBe(true);
+    });
+
+    it('[::1] with port', () => {
+      expect(isLocalUrl('http://[::1]:8080/files')).toBe(true);
+    });
+
+    it('10.0.0.1 (private range)', () => {
+      expect(isLocalUrl('http://10.0.0.1')).toBe(true);
+    });
+
+    it('10.255.255.255 (end of 10.x range)', () => {
+      expect(isLocalUrl('http://10.255.255.255')).toBe(true);
+    });
+
+    it('10.0.0.5 with path', () => {
+      expect(isLocalUrl('http://10.0.0.5/attachments/doc.pdf')).toBe(true);
+    });
+
+    it('192.168.1.1 (private range)', () => {
+      expect(isLocalUrl('http://192.168.1.1')).toBe(true);
+    });
+
+    it('192.168.0.100 with port', () => {
+      expect(isLocalUrl('http://192.168.0.100:8443/files')).toBe(true);
+    });
+
+    it('192.168.255.255 (end of 192.168.x range)', () => {
+      expect(isLocalUrl('http://192.168.255.255')).toBe(true);
+    });
+
+    it('172.16.0.1 (start of private range)', () => {
+      expect(isLocalUrl('http://172.16.0.1')).toBe(true);
+    });
+
+    it('172.31.255.255 (end of private range)', () => {
+      expect(isLocalUrl('http://172.31.255.255')).toBe(true);
+    });
+
+    it('172.20.10.5 (middle of private range)', () => {
+      expect(isLocalUrl('http://172.20.10.5/api/files')).toBe(true);
+    });
+
+    it('.local TLD', () => {
+      expect(isLocalUrl('http://jira.company.local/files/123')).toBe(true);
+    });
+
+    it('.local TLD with port', () => {
+      expect(isLocalUrl('http://myserver.local:8080')).toBe(true);
+    });
+
+    it('.internal TLD', () => {
+      expect(isLocalUrl('http://api.internal/files')).toBe(true);
+    });
+
+    it('.internal TLD with subdomain', () => {
+      expect(isLocalUrl('http://jira.corp.internal:9090/attachments')).toBe(
+        true
+      );
+    });
+  });
+
+  describe('should return false for public/external URLs', () => {
+    it('example.com', () => {
+      expect(isLocalUrl('https://example.com')).toBe(false);
+    });
+
+    it('api.github.com', () => {
+      expect(isLocalUrl('https://api.github.com/repos')).toBe(false);
+    });
+
+    it('jira.atlassian.net', () => {
+      expect(isLocalUrl('https://jira.atlassian.net/rest/api/file')).toBe(
+        false
+      );
+    });
+
+    it('public IP address', () => {
+      expect(isLocalUrl('http://8.8.8.8')).toBe(false);
+    });
+
+    it('public IP address 1.2.3.4', () => {
+      expect(isLocalUrl('http://1.2.3.4/files')).toBe(false);
+    });
+
+    it('128.0.0.1 (not in loopback range)', () => {
+      expect(isLocalUrl('http://128.0.0.1')).toBe(false);
+    });
+
+    it('192.169.1.1 (not in 192.168.x range)', () => {
+      expect(isLocalUrl('http://192.169.1.1')).toBe(false);
+    });
+
+    it('172.15.0.1 (below private range)', () => {
+      expect(isLocalUrl('http://172.15.0.1')).toBe(false);
+    });
+
+    it('172.32.0.1 (above private range)', () => {
+      expect(isLocalUrl('http://172.32.0.1')).toBe(false);
+    });
+
+    it('11.0.0.1 (not in 10.x range)', () => {
+      expect(isLocalUrl('http://11.0.0.1')).toBe(false);
+    });
+
+    it('hostname that contains "local" but is not .local TLD', () => {
+      expect(isLocalUrl('https://localfiles.example.com/doc.pdf')).toBe(false);
+    });
+
+    it('hostname that contains "internal" but is not .internal TLD', () => {
+      expect(isLocalUrl('https://internal-api.example.com/files')).toBe(false);
+    });
+  });
+
+  describe('should return false for edge cases (fail open)', () => {
+    it('undefined', () => {
+      expect(isLocalUrl(undefined)).toBe(false);
+    });
+
+    it('empty string', () => {
+      expect(isLocalUrl('')).toBe(false);
+    });
+
+    it('invalid URL', () => {
+      expect(isLocalUrl('not-a-url')).toBe(false);
+    });
+
+    it('relative path', () => {
+      expect(isLocalUrl('/api/files/123')).toBe(false);
+    });
+  });
+});
+
+describe('isNonRetryableConnectionError', () => {
+  describe('should return true for non-retryable connection errors', () => {
+    it('ECONNREFUSED', () => {
+      const error = createAxiosError({ code: 'ECONNREFUSED' });
+      expect(isNonRetryableConnectionError(error)).toBe(true);
+    });
+
+    it('ENOTFOUND', () => {
+      const error = createAxiosError({ code: 'ENOTFOUND' });
+      expect(isNonRetryableConnectionError(error)).toBe(true);
+    });
+
+    it('ENETUNREACH', () => {
+      const error = createAxiosError({ code: 'ENETUNREACH' });
+      expect(isNonRetryableConnectionError(error)).toBe(true);
+    });
+
+    it('EHOSTUNREACH', () => {
+      const error = createAxiosError({ code: 'EHOSTUNREACH' });
+      expect(isNonRetryableConnectionError(error)).toBe(true);
+    });
+  });
+
+  describe('should return false for potentially transient errors', () => {
+    it('ECONNABORTED (timeout)', () => {
+      const error = createAxiosError({ code: 'ECONNABORTED' });
+      expect(isNonRetryableConnectionError(error)).toBe(false);
+    });
+
+    it('ECONNRESET', () => {
+      const error = createAxiosError({ code: 'ECONNRESET' });
+      expect(isNonRetryableConnectionError(error)).toBe(false);
+    });
+
+    it('ETIMEDOUT', () => {
+      const error = createAxiosError({ code: 'ETIMEDOUT' });
+      expect(isNonRetryableConnectionError(error)).toBe(false);
+    });
+
+    it('ERR_CANCELED', () => {
+      const error = createAxiosError({ code: 'ERR_CANCELED' });
+      expect(isNonRetryableConnectionError(error)).toBe(false);
+    });
+
+    it('ERR_BAD_RESPONSE', () => {
+      const error = createAxiosError({ code: 'ERR_BAD_RESPONSE' });
+      expect(isNonRetryableConnectionError(error)).toBe(false);
+    });
+  });
+
+  describe('should return false for edge cases', () => {
+    it('no error code', () => {
+      const error = createAxiosError({});
+      expect(isNonRetryableConnectionError(error)).toBe(false);
+    });
+
+    it('HTTP error with status code (not a connection error)', () => {
+      const error = createAxiosError({ status: 500 });
+      expect(isNonRetryableConnectionError(error)).toBe(false);
+    });
+  });
+});
+
+describe('axiosClient retryCondition integration', () => {
+  beforeEach(() => {
+    jest.spyOn(console, 'warn').mockImplementation();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  /**
+   * We test the retry condition indirectly by importing the axiosClient and
+   * verifying its behavior. Since we can't easily extract the retryCondition
+   * callback, we test through the helpers which the retryCondition delegates to.
+   *
+   * The key invariant is:
+   * - isLocalUrl(url) === true  => should NOT retry
+   * - isNonRetryableConnectionError(error) === true  => should NOT retry
+   * - Otherwise, delegate to the existing retry logic
+   */
+
+  it('should not retry ECONNREFUSED to a local URL', () => {
+    const error = createAxiosError({
+      code: 'ECONNREFUSED',
+      url: 'http://localhost:8080/files',
+    });
+
+    // Both conditions match — should definitely not retry
+    expect(isLocalUrl(error.config?.url)).toBe(true);
+    expect(isNonRetryableConnectionError(error)).toBe(true);
+  });
+
+  it('should not retry ENOTFOUND to a .local TLD', () => {
+    const error = createAxiosError({
+      code: 'ENOTFOUND',
+      url: 'http://jira.company.local/attachments/123',
+    });
+
+    expect(isLocalUrl(error.config?.url)).toBe(true);
+    expect(isNonRetryableConnectionError(error)).toBe(true);
+  });
+
+  it('should not retry ECONNREFUSED to a public URL (caught by error code)', () => {
+    const error = createAxiosError({
+      code: 'ECONNREFUSED',
+      url: 'https://api.example.com/files',
+    });
+
+    // URL looks public, but the error code is non-retryable
+    expect(isLocalUrl(error.config?.url)).toBe(false);
+    expect(isNonRetryableConnectionError(error)).toBe(true);
+  });
+
+  it('should not retry ENOTFOUND to a public-looking URL (caught by error code)', () => {
+    const error = createAxiosError({
+      code: 'ENOTFOUND',
+      url: 'https://doesnotexist.example.com/files',
+    });
+
+    expect(isLocalUrl(error.config?.url)).toBe(false);
+    expect(isNonRetryableConnectionError(error)).toBe(true);
+  });
+
+  it('should not retry any error to a private IP address', () => {
+    const error = createAxiosError({
+      code: 'ECONNRESET',
+      url: 'http://192.168.1.50:3000/attachments',
+    });
+
+    // ECONNRESET is normally retryable, but the URL is local
+    expect(isLocalUrl(error.config?.url)).toBe(true);
+  });
+
+  it('should allow retry for 500 error to a public URL', () => {
+    const error = createAxiosError({
+      code: 'ERR_BAD_RESPONSE',
+      url: 'https://api.example.com/files',
+      status: 500,
+    });
+
+    // Neither condition blocks retrying
+    expect(isLocalUrl(error.config?.url)).toBe(false);
+    expect(isNonRetryableConnectionError(error)).toBe(false);
+  });
+
+  it('should allow retry for ECONNRESET to a public URL', () => {
+    const error = createAxiosError({
+      code: 'ECONNRESET',
+      url: 'https://api.example.com/files',
+    });
+
+    // ECONNRESET is transient, URL is public — should retry
+    expect(isLocalUrl(error.config?.url)).toBe(false);
+    expect(isNonRetryableConnectionError(error)).toBe(false);
+  });
+
+  it('should allow retry for ETIMEDOUT to a public URL', () => {
+    const error = createAxiosError({
+      code: 'ETIMEDOUT',
+      url: 'https://api.example.com/files',
+    });
+
+    expect(isLocalUrl(error.config?.url)).toBe(false);
+    expect(isNonRetryableConnectionError(error)).toBe(false);
+  });
+});

--- a/src/http/axios-client.ts
+++ b/src/http/axios-client.ts
@@ -9,6 +9,10 @@
  * 2. Idempotent requests (defaults include GET, HEAD, OPTIONS, PUT).
  * 3. All 5xx server errors.
  *
+ * Non-Retry Conditions:
+ * 1. Requests to local/private URLs (localhost, private IPs, .local/.internal TLDs).
+ * 2. Definitive connection failures (ECONNREFUSED, ENOTFOUND, ENETUNREACH, EHOSTUNREACH).
+ *
  * Retry Strategy:
  * - A maximum of 5 retries are attempted.
  * - Exponential backoff delay is applied between retries, increasing with each retry attempt.
@@ -20,10 +24,124 @@
  * Exported:
  * - `axios`: Original axios instance for additional customizations or direct use.
  * - `axiosClient`: Configured axios instance with retry logic.
+ * - `isLocalUrl`: Helper to check if a URL points to a local/private address.
+ * - `isNonRetryableConnectionError`: Helper to check if an error indicates a definitively unreachable host.
  */
 
 import axios, { AxiosError } from 'axios';
 import axiosRetry from 'axios-retry';
+
+/**
+ * Error codes that indicate the target host is definitively unreachable.
+ * These are distinct from transient errors (like ETIMEDOUT or ECONNRESET)
+ * which could succeed on retry.
+ */
+const NON_RETRYABLE_ERROR_CODES = new Set([
+  'ECONNREFUSED', // Nothing is listening at the target address
+  'ENOTFOUND', // DNS resolution failed entirely
+  'ENETUNREACH', // Network is unreachable
+  'EHOSTUNREACH', // Host is unreachable
+]);
+
+/**
+ * Checks whether a URL points to a local or private network address.
+ *
+ * This detects:
+ * - `localhost` (any port)
+ * - IPv4 loopback range (`127.x.x.x`)
+ * - IPv6 loopback (`::1`, `[::1]`)
+ * - Private IPv4 ranges (`10.x.x.x`, `172.16-31.x.x`, `192.168.x.x`)
+ * - `0.0.0.0`
+ * - `.local` TLD (mDNS / local domain)
+ * - `.internal` TLD
+ *
+ * @param url - The URL string to check
+ * @returns `true` if the URL targets a local/private address, `false` otherwise
+ *   (including for undefined or unparseable URLs — fail open to let normal error handling take over)
+ */
+function isLocalUrl(url?: string): boolean {
+  if (!url) {
+    return false;
+  }
+
+  try {
+    const parsed = new URL(url);
+    const hostname = parsed.hostname.toLowerCase();
+
+    // localhost
+    if (hostname === 'localhost') {
+      return true;
+    }
+
+    // 0.0.0.0
+    if (hostname === '0.0.0.0') {
+      return true;
+    }
+
+    // IPv6 loopback — URL parser strips brackets, so ::1 is the hostname
+    if (hostname === '::1' || hostname === '[::1]') {
+      return true;
+    }
+
+    // .local and .internal TLDs
+    if (hostname.endsWith('.local') || hostname.endsWith('.internal')) {
+      return true;
+    }
+
+    // IPv4 checks: loopback and private ranges
+    const ipv4Match = hostname.match(
+      /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/
+    );
+    if (ipv4Match) {
+      const [, a, b] = ipv4Match.map(Number);
+
+      // 127.x.x.x — loopback
+      if (a === 127) {
+        return true;
+      }
+
+      // 10.x.x.x — private
+      if (a === 10) {
+        return true;
+      }
+
+      // 192.168.x.x — private
+      if (a === 192 && b === 168) {
+        return true;
+      }
+
+      // 172.16.0.0 – 172.31.255.255 — private
+      if (a === 172 && b >= 16 && b <= 31) {
+        return true;
+      }
+    }
+
+    return false;
+  } catch {
+    // URL parsing failed — fail open, let normal error handling take over
+    return false;
+  }
+}
+
+/**
+ * Checks whether an Axios error indicates a definitively unreachable host.
+ *
+ * These error codes mean the target cannot be reached at all — retrying will
+ * not help. This is distinct from transient errors like ETIMEDOUT or
+ * ECONNRESET which could succeed on a subsequent attempt.
+ *
+ * Non-retryable codes:
+ * - `ECONNREFUSED` — nothing is listening at the target address
+ * - `ENOTFOUND` — DNS resolution failed entirely
+ * - `ENETUNREACH` — network is unreachable
+ * - `EHOSTUNREACH` — host is unreachable
+ *
+ * @param error - The Axios error to check
+ * @returns `true` if the error indicates the host is definitively unreachable
+ */
+function isNonRetryableConnectionError(error: AxiosError): boolean {
+  return !!error.code && NON_RETRYABLE_ERROR_CODES.has(error.code);
+}
 
 const axiosClient = axios.create();
 
@@ -44,6 +162,28 @@ axiosRetry(axiosClient, {
     return delay;
   },
   retryCondition: (error: AxiosError) => {
+    // Never retry requests to local/private URLs — they will never succeed
+    // from the cloud environment.
+    if (isLocalUrl(error.config?.url)) {
+      console.warn(
+        `Request to ${error.config?.url} failed with ${
+          error.code ?? 'unknown error'
+        }. ` +
+          `Not retrying because the URL points to a local or private address.`
+      );
+      return false;
+    }
+
+    // Never retry definitive connection failures — the host is unreachable,
+    // and retrying with exponential backoff will only waste time.
+    if (isNonRetryableConnectionError(error)) {
+      console.warn(
+        `Request to ${error.config?.url} failed with ${error.code}. ` +
+          `Not retrying because the target host appears to be unreachable.`
+      );
+      return false;
+    }
+
     return (
       (axiosRetry.isNetworkOrIdempotentRequestError(error) &&
         error.response?.status !== 429) ||
@@ -58,4 +198,4 @@ axiosRetry(axiosClient, {
   },
 });
 
-export { axios, axiosClient };
+export { axios, axiosClient, isLocalUrl, isNonRetryableConnectionError };

--- a/src/http/axios-client.ts
+++ b/src/http/axios-client.ts
@@ -10,7 +10,7 @@
  * 3. All 5xx server errors.
  *
  * Non-Retry Conditions:
- * 1. Requests to local/private URLs (localhost, private IPs, .local/.internal TLDs).
+ * 1. Requests to local/private URLs (localhost, private IPs, link-local, IPv6 ULA, .local/.internal TLDs).
  * 2. Definitive connection failures (ECONNREFUSED, ENOTFOUND, ENETUNREACH, EHOSTUNREACH).
  *
  * Retry Strategy:
@@ -50,7 +50,10 @@ const NON_RETRYABLE_ERROR_CODES = new Set([
  * - `localhost` (any port)
  * - IPv4 loopback range (`127.x.x.x`)
  * - IPv6 loopback (`::1`, `[::1]`)
+ * - IPv6 link-local (`fe80::/10`)
+ * - IPv6 unique-local (`fc00::/7`, i.e. `fc00::` and `fd00::` prefixes)
  * - Private IPv4 ranges (`10.x.x.x`, `172.16-31.x.x`, `192.168.x.x`)
+ * - Link-local IPv4 range (`169.254.x.x`, includes cloud metadata endpoints)
  * - `0.0.0.0`
  * - `.local` TLD (mDNS / local domain)
  * - `.internal` TLD
@@ -83,6 +86,20 @@ function isLocalUrl(url?: string): boolean {
       return true;
     }
 
+    // IPv6 link-local (fe80::/10) and unique-local (fc00::/7 covers fc00:: and fd00::)
+    // URL parser keeps brackets for IPv6, so hostname looks like "[fe80::1]".
+    // We strip brackets before checking prefixes.
+    if (hostname.startsWith('[')) {
+      const inner = hostname.slice(1, -1); // Remove [ and ]
+      if (
+        inner.startsWith('fe80:') ||
+        inner.startsWith('fc00:') ||
+        inner.startsWith('fd') // fd00::/8 is the commonly used subset of fc00::/7
+      ) {
+        return true;
+      }
+    }
+
     // .local and .internal TLDs
     if (hostname.endsWith('.local') || hostname.endsWith('.internal')) {
       return true;
@@ -112,6 +129,11 @@ function isLocalUrl(url?: string): boolean {
 
       // 172.16.0.0 – 172.31.255.255 — private
       if (a === 172 && b >= 16 && b <= 31) {
+        return true;
+      }
+
+      // 169.254.x.x — link-local (includes cloud metadata endpoints like 169.254.169.254)
+      if (a === 169 && b === 254) {
         return true;
       }
     }

--- a/src/multithreading/worker-adapter/worker-adapter.test.ts
+++ b/src/multithreading/worker-adapter/worker-adapter.test.ts
@@ -475,11 +475,10 @@ describe(WorkerAdapter.name, () => {
   });
 
   describe(WorkerAdapter.prototype.processAttachment.name, () => {
-    const createMockHttpStream = (headers: Record<string, string> = {}) =>
-      ({
-        headers,
-        data: { destroy: jest.fn() },
-      }) as any;
+    const createMockHttpStream = (headers: Record<string, string> = {}) => ({
+      headers,
+      data: { destroy: jest.fn() },
+    });
 
     beforeEach(() => {
       adapter.initializeRepos([{ itemType: 'ssor_attachment' }]);
@@ -496,11 +495,13 @@ describe(WorkerAdapter.name, () => {
         }),
       });
 
-      adapter['uploader'].getArtifactUploadUrl = jest
-        .fn()
-        .mockResolvedValue({
-          response: { artifact_id: 'art_1', upload_url: 'https://upload', form_data: [] },
-        });
+      adapter['uploader'].getArtifactUploadUrl = jest.fn().mockResolvedValue({
+        response: {
+          artifact_id: 'art_1',
+          upload_url: 'https://upload',
+          form_data: [],
+        },
+      });
       adapter['uploader'].streamArtifact = jest
         .fn()
         .mockResolvedValue({ response: {} });
@@ -533,11 +534,13 @@ describe(WorkerAdapter.name, () => {
         }),
       });
 
-      adapter['uploader'].getArtifactUploadUrl = jest
-        .fn()
-        .mockResolvedValue({
-          response: { artifact_id: 'art_2', upload_url: 'https://upload', form_data: [] },
-        });
+      adapter['uploader'].getArtifactUploadUrl = jest.fn().mockResolvedValue({
+        response: {
+          artifact_id: 'art_2',
+          upload_url: 'https://upload',
+          form_data: [],
+        },
+      });
       adapter['uploader'].streamArtifact = jest
         .fn()
         .mockResolvedValue({ response: {} });
@@ -566,11 +569,13 @@ describe(WorkerAdapter.name, () => {
         httpStream: createMockHttpStream({}),
       });
 
-      adapter['uploader'].getArtifactUploadUrl = jest
-        .fn()
-        .mockResolvedValue({
-          response: { artifact_id: 'art_3', upload_url: 'https://upload', form_data: [] },
-        });
+      adapter['uploader'].getArtifactUploadUrl = jest.fn().mockResolvedValue({
+        response: {
+          artifact_id: 'art_3',
+          upload_url: 'https://upload',
+          form_data: [],
+        },
+      });
       adapter['uploader'].streamArtifact = jest
         .fn()
         .mockResolvedValue({ response: {} });


### PR DESCRIPTION
## Description

<!--
    A brief description of what the PR does/changes.
    Use active voice and present tense, e.g., This PR fixes ...
-->
This PR introduces changes, that don't retry local URLs or URLs that fail with responses that shouldn't be retried.
We have seen some issues with our customers that had local URLs for attachments, that failed to be extracted, but we still retried and kept retrying for weeks, failing to complete the sync.
## Connected Issues

<!--
    DevRev issue(s) full link(s) (e.g. https://app.devrev.ai/devrev/works/ISS-123).
-->
- [#ISS-269633](https://app.devrev.ai/devrev/works/ISS-269633)

## Checklist

- [x] Tests added/updated and ran with `npm run test` OR no tests needed.
- [x] Ran backwards compatibility tests with `npm run test:backwards-compatibility`.
- [x] Code formatted and checked with `npm run lint`.
- [x] Tested airdrop-template linked to this PR.
- [x] Documentation updated and provided a link to PR / new docs OR no docs needed.
