### PR TITLE
Fix the way '--local' flag is parsed

### DIFF
--- a/src/multithreading/spawn/spawn.ts
+++ b/src/multithreading/spawn/spawn.ts
@@ -89,7 +89,7 @@ export async function spawn<ConnectorState>({
 
   // Read the command line arguments to check if the local flag is passed.
   const argv = await yargs(hideBin(process.argv)).argv;
-  if (argv._.includes('local')) {
+  if (argv._.includes('local') || argv.local) {
     options = {
       ...(options || {}),
       isLocalDevelopment: true,


### PR DESCRIPTION
## Description

<!--
    A brief description of what the PR does/changes.
    Use active voice and present tense, e.g., This PR fixes ...
-->
Now supporting `local` as both a positional argument and a flag `--local`.
## Connected Issues

<!--
    DevRev issue(s) full link(s) (e.g. https://app.devrev.ai/devrev/works/ISS-123).
-->
- [#ISS-269670](https://app.devrev.ai/devrev/works/ISS-269670)
## Checklist

- [x] Tests added/updated and ran with `npm run test` OR no tests needed.
- [x] Ran backwards compatibility tests with `npm run test:backwards-compatibility`.
- [x] Code formatted and checked with `npm run lint`.
- [x] Tested airdrop-template linked to this PR.
- [x] Documentation updated and provided a link to PR / new docs OR no docs needed.
