### PR TITLE
chore: Update extraction time calculation to correct phase

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@devrev/ts-adaas",
-  "version": "1.19.1",
+  "version": "1.19.2-beta.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@devrev/ts-adaas",
-      "version": "1.19.1",
+      "version": "1.19.2-beta.0",
       "license": "ISC",
       "dependencies": {
         "@devrev/typescript-sdk": "^1.1.59",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@devrev/ts-adaas",
-  "version": "1.19.1",
+  "version": "1.19.2-beta.0",
   "description": "Typescript library containing the ADaaS(AirDrop as a Service) control protocol.",
   "type": "commonjs",
   "main": "./dist/index.js",

--- a/src/state/state.interfaces.ts
+++ b/src/state/state.interfaces.ts
@@ -15,10 +15,10 @@ export interface SdkState {
    */
   lastSuccessfulSyncStarted?: string;
   /** The pending (not yet committed) oldest extraction boundary (ISO 8601 timestamp).
-   *  Set on StartExtractingData, reused across subsequent phases, cleared on AttachmentExtractionDone. */
+   *  Set on StartExtractingMetadata, reused across subsequent phases, cleared on AttachmentExtractionDone. */
   pendingWorkersOldest?: string;
   /** The pending (not yet committed) newest extraction boundary (ISO 8601 timestamp).
-   *  Set on StartExtractingData, reused across subsequent phases, cleared on AttachmentExtractionDone. */
+   *  Set on StartExtractingMetadata, reused across subsequent phases, cleared on AttachmentExtractionDone. */
   pendingWorkersNewest?: string;
   /** The oldest point of extraction (ISO 8601 timestamp). */
   workersOldest?: string;

--- a/src/state/state.test.ts
+++ b/src/state/state.test.ts
@@ -410,6 +410,9 @@ describe(State.name, () => {
         '2025-06-01T00:00:00.000Z'
       );
       expect(state.state.pendingWorkersNewest).toBe('2025-06-01T00:00:00.000Z');
+      // Raw platform fields should be removed from event context
+      expect(event.payload.event_context.extraction_start_time).toBeUndefined();
+      expect(event.payload.event_context.extraction_end_time).toBeUndefined();
     });
 
     it('should skip resolution when extraction_end_time has no type', async () => {
@@ -449,6 +452,9 @@ describe(State.name, () => {
         '2024-01-01T00:00:00.000Z'
       );
       expect(event.payload.event_context.extract_to).toBeUndefined();
+      // Raw platform fields should be removed from event context
+      expect(event.payload.event_context.extraction_start_time).toBeUndefined();
+      expect(event.payload.event_context.extraction_end_time).toBeUndefined();
     });
 
     it('should skip resolution when both extraction times have no type', async () => {
@@ -487,6 +493,9 @@ describe(State.name, () => {
       expect(processExitSpy).not.toHaveBeenCalled();
       expect(event.payload.event_context.extract_from).toBeUndefined();
       expect(event.payload.event_context.extract_to).toBeUndefined();
+      // Raw platform fields should be removed from event context
+      expect(event.payload.event_context.extraction_start_time).toBeUndefined();
+      expect(event.payload.event_context.extraction_end_time).toBeUndefined();
     });
   });
 
@@ -596,6 +605,9 @@ describe(State.name, () => {
 
       // Assert: process.exit should NOT have been called
       expect(processExitSpy).not.toHaveBeenCalled();
+      // Raw platform fields should be removed from event context
+      expect(event.payload.event_context.extraction_start_time).toBeUndefined();
+      expect(event.payload.event_context.extraction_end_time).toBeUndefined();
     });
 
     it('should not validate when only extract_from is set', async () => {
@@ -627,6 +639,8 @@ describe(State.name, () => {
 
       // Assert: process.exit should NOT have been called
       expect(processExitSpy).not.toHaveBeenCalled();
+      // Raw platform fields should be removed from event context
+      expect(event.payload.event_context.extraction_start_time).toBeUndefined();
     });
 
     it('should not exit when extract_from is UNBOUNDED and extract_to is a real timestamp', async () => {
@@ -661,6 +675,9 @@ describe(State.name, () => {
 
       // Assert: process.exit should NOT have been called
       expect(processExitSpy).not.toHaveBeenCalled();
+      // Raw platform fields should be removed from event context
+      expect(event.payload.event_context.extraction_start_time).toBeUndefined();
+      expect(event.payload.event_context.extraction_end_time).toBeUndefined();
     });
   });
 
@@ -717,6 +734,9 @@ describe(State.name, () => {
         '1970-01-01T00:00:00.000Z'
       );
       expect(event.payload.event_context.extract_to).toBe(FIXED_NOW);
+      // Raw platform fields should be removed from event context
+      expect(event.payload.event_context.extraction_start_time).toBeUndefined();
+      expect(event.payload.event_context.extraction_end_time).toBeUndefined();
     });
 
     it('should overwrite pending values on a retry (new StartExtractingMetadata after failure)', async () => {
@@ -760,6 +780,9 @@ describe(State.name, () => {
       expect(state.state.pendingWorkersOldest).toBe('1970-01-01T00:00:00.000Z');
       expect(state.state.pendingWorkersNewest).toBe(FIXED_NOW);
       expect(state.state.pendingWorkersNewest).not.toBe(staleNewest);
+      // Raw platform fields should be removed from event context
+      expect(event.payload.event_context.extraction_start_time).toBeUndefined();
+      expect(event.payload.event_context.extraction_end_time).toBeUndefined();
     });
 
     it('should reuse pending values from state on ContinueExtractingData instead of re-resolving', async () => {

--- a/src/state/state.test.ts
+++ b/src/state/state.test.ts
@@ -305,7 +305,7 @@ describe(State.name, () => {
       // Arrange: WORKERS_NEWEST type but state has no workersNewest
       const event = createMockEvent(mockServer.baseUrl, {
         payload: {
-          event_type: EventType.StartExtractingData,
+          event_type: EventType.StartExtractingMetadata,
           event_context: {
             extraction_start_time: {
               type: TimeValueType.WORKERS_NEWEST,
@@ -338,7 +338,7 @@ describe(State.name, () => {
       // Arrange: WORKERS_NEWEST type but state has no workersNewest
       const event = createMockEvent(mockServer.baseUrl, {
         payload: {
-          event_type: EventType.StartExtractingData,
+          event_type: EventType.StartExtractingMetadata,
           event_context: {
             extraction_start_time: {
               type: TimeValueType.UNBOUNDED,
@@ -379,7 +379,7 @@ describe(State.name, () => {
           snap_in_version_id: 'test_snap_in_version_id',
         },
         payload: {
-          event_type: EventType.StartExtractingData,
+          event_type: EventType.StartExtractingMetadata,
           event_context: {
             extraction_start_time: {} as unknown as TimeValue,
             extraction_end_time: {
@@ -419,7 +419,7 @@ describe(State.name, () => {
           snap_in_version_id: 'test_snap_in_version_id',
         },
         payload: {
-          event_type: EventType.StartExtractingData,
+          event_type: EventType.StartExtractingMetadata,
           event_context: {
             extraction_start_time: {
               type: TimeValueType.ABSOLUTE_TIME,
@@ -458,7 +458,7 @@ describe(State.name, () => {
           snap_in_version_id: 'test_snap_in_version_id',
         },
         payload: {
-          event_type: EventType.StartExtractingData,
+          event_type: EventType.StartExtractingMetadata,
           event_context: {
             extraction_start_time: {
               value: 'some-value',
@@ -495,7 +495,7 @@ describe(State.name, () => {
       // Arrange: start is after end (inverted window)
       const event = createMockEvent(mockServer.baseUrl, {
         payload: {
-          event_type: EventType.StartExtractingData,
+          event_type: EventType.StartExtractingMetadata,
           event_context: {
             extraction_start_time: {
               type: TimeValueType.ABSOLUTE_TIME,
@@ -531,7 +531,7 @@ describe(State.name, () => {
       // Arrange: start equals end (zero-width window)
       const event = createMockEvent(mockServer.baseUrl, {
         payload: {
-          event_type: EventType.StartExtractingData,
+          event_type: EventType.StartExtractingMetadata,
           event_context: {
             extraction_start_time: {
               type: TimeValueType.ABSOLUTE_TIME,
@@ -567,7 +567,7 @@ describe(State.name, () => {
       // Arrange: valid window
       const event = createMockEvent(mockServer.baseUrl, {
         payload: {
-          event_type: EventType.StartExtractingData,
+          event_type: EventType.StartExtractingMetadata,
           event_context: {
             extraction_start_time: {
               type: TimeValueType.ABSOLUTE_TIME,
@@ -602,7 +602,7 @@ describe(State.name, () => {
       // Arrange: only start, no end
       const event = createMockEvent(mockServer.baseUrl, {
         payload: {
-          event_type: EventType.StartExtractingData,
+          event_type: EventType.StartExtractingMetadata,
           event_context: {
             extraction_start_time: {
               type: TimeValueType.ABSOLUTE_TIME,
@@ -633,7 +633,7 @@ describe(State.name, () => {
       // Arrange: UNBOUNDED start (epoch) with a real ABSOLUTE end timestamp
       const event = createMockEvent(mockServer.baseUrl, {
         payload: {
-          event_type: EventType.StartExtractingData,
+          event_type: EventType.StartExtractingMetadata,
           event_context: {
             extraction_start_time: {
               type: TimeValueType.UNBOUNDED,
@@ -676,14 +676,14 @@ describe(State.name, () => {
       jest.useRealTimers();
     });
 
-    it('should store resolved values in pendingWorkersOldest/pendingWorkersNewest on StartExtractingData', async () => {
+    it('should store resolved values in pendingWorkersOldest/pendingWorkersNewest on StartExtractingMetadata', async () => {
       // Arrange
       const event = createMockEvent(mockServer.baseUrl, {
         context: {
           snap_in_version_id: '',
         },
         payload: {
-          event_type: EventType.StartExtractingData,
+          event_type: EventType.StartExtractingMetadata,
           event_context: {
             extraction_start_time: {
               type: TimeValueType.UNBOUNDED,
@@ -719,7 +719,7 @@ describe(State.name, () => {
       expect(event.payload.event_context.extract_to).toBe(FIXED_NOW);
     });
 
-    it('should overwrite pending values on a retry (new StartExtractingData after failure)', async () => {
+    it('should overwrite pending values on a retry (new StartExtractingMetadata after failure)', async () => {
       // Arrange: state has stale pending values from a previous failed attempt
       const staleOldest = '2026-03-25T08:00:00.000Z';
       const staleNewest = '2026-03-25T09:00:00.000Z';
@@ -729,7 +729,7 @@ describe(State.name, () => {
           snap_in_version_id: 'test_snap_in_version_id',
         },
         payload: {
-          event_type: EventType.StartExtractingData,
+          event_type: EventType.StartExtractingMetadata,
           event_context: {
             extraction_start_time: {
               type: TimeValueType.UNBOUNDED,
@@ -763,7 +763,7 @@ describe(State.name, () => {
     });
 
     it('should reuse pending values from state on ContinueExtractingData instead of re-resolving', async () => {
-      // Arrange: state has pending values from a prior StartExtractingData phase
+      // Arrange: state has pending values from a prior StartExtractingMetadata phase
       const pendingOldest = '1970-01-01T00:00:00.000Z';
       const pendingNewest = '2026-03-26T08:00:00.000Z'; // Earlier than FIXED_NOW
 
@@ -836,7 +836,7 @@ describe(State.name, () => {
     });
 
     it('should reuse pending values on StartExtractingAttachments', async () => {
-      // Arrange: state has pending values from the StartExtractingData phase
+      // Arrange: state has pending values from the StartExtractingMetadata phase
       const pendingOldest = '1970-01-01T00:00:00.000Z';
       const pendingNewest = '2026-03-26T08:00:00.000Z';
 

--- a/src/state/state.test.ts
+++ b/src/state/state.test.ts
@@ -410,9 +410,6 @@ describe(State.name, () => {
         '2025-06-01T00:00:00.000Z'
       );
       expect(state.state.pendingWorkersNewest).toBe('2025-06-01T00:00:00.000Z');
-      // Raw platform fields should be removed from event context
-      expect(event.payload.event_context.extraction_start_time).toBeUndefined();
-      expect(event.payload.event_context.extraction_end_time).toBeUndefined();
     });
 
     it('should skip resolution when extraction_end_time has no type', async () => {
@@ -452,9 +449,6 @@ describe(State.name, () => {
         '2024-01-01T00:00:00.000Z'
       );
       expect(event.payload.event_context.extract_to).toBeUndefined();
-      // Raw platform fields should be removed from event context
-      expect(event.payload.event_context.extraction_start_time).toBeUndefined();
-      expect(event.payload.event_context.extraction_end_time).toBeUndefined();
     });
 
     it('should skip resolution when both extraction times have no type', async () => {
@@ -493,9 +487,6 @@ describe(State.name, () => {
       expect(processExitSpy).not.toHaveBeenCalled();
       expect(event.payload.event_context.extract_from).toBeUndefined();
       expect(event.payload.event_context.extract_to).toBeUndefined();
-      // Raw platform fields should be removed from event context
-      expect(event.payload.event_context.extraction_start_time).toBeUndefined();
-      expect(event.payload.event_context.extraction_end_time).toBeUndefined();
     });
   });
 
@@ -605,9 +596,6 @@ describe(State.name, () => {
 
       // Assert: process.exit should NOT have been called
       expect(processExitSpy).not.toHaveBeenCalled();
-      // Raw platform fields should be removed from event context
-      expect(event.payload.event_context.extraction_start_time).toBeUndefined();
-      expect(event.payload.event_context.extraction_end_time).toBeUndefined();
     });
 
     it('should not validate when only extract_from is set', async () => {
@@ -639,8 +627,6 @@ describe(State.name, () => {
 
       // Assert: process.exit should NOT have been called
       expect(processExitSpy).not.toHaveBeenCalled();
-      // Raw platform fields should be removed from event context
-      expect(event.payload.event_context.extraction_start_time).toBeUndefined();
     });
 
     it('should not exit when extract_from is UNBOUNDED and extract_to is a real timestamp', async () => {
@@ -675,9 +661,6 @@ describe(State.name, () => {
 
       // Assert: process.exit should NOT have been called
       expect(processExitSpy).not.toHaveBeenCalled();
-      // Raw platform fields should be removed from event context
-      expect(event.payload.event_context.extraction_start_time).toBeUndefined();
-      expect(event.payload.event_context.extraction_end_time).toBeUndefined();
     });
   });
 
@@ -734,9 +717,6 @@ describe(State.name, () => {
         '1970-01-01T00:00:00.000Z'
       );
       expect(event.payload.event_context.extract_to).toBe(FIXED_NOW);
-      // Raw platform fields should be removed from event context
-      expect(event.payload.event_context.extraction_start_time).toBeUndefined();
-      expect(event.payload.event_context.extraction_end_time).toBeUndefined();
     });
 
     it('should overwrite pending values on a retry (new StartExtractingMetadata after failure)', async () => {
@@ -780,9 +760,6 @@ describe(State.name, () => {
       expect(state.state.pendingWorkersOldest).toBe('1970-01-01T00:00:00.000Z');
       expect(state.state.pendingWorkersNewest).toBe(FIXED_NOW);
       expect(state.state.pendingWorkersNewest).not.toBe(staleNewest);
-      // Raw platform fields should be removed from event context
-      expect(event.payload.event_context.extraction_start_time).toBeUndefined();
-      expect(event.payload.event_context.extraction_end_time).toBeUndefined();
     });
 
     it('should reuse pending values from state on ContinueExtractingData instead of re-resolving', async () => {

--- a/src/state/state.ts
+++ b/src/state/state.ts
@@ -85,11 +85,11 @@ export async function createAdapterState<ConnectorState>({
     }
 
     // Resolve extraction timestamps from TimeValue objects, or reuse pending values from a prior invocation.
-    // On StartExtractingData: resolve fresh from TimeValue objects and store in pending state (always overwrite).
-    // On all other events: reuse the pending values cached during StartExtractingData.
+    // On StartExtractingMetadata: resolve fresh from TimeValue objects and store in pending state (always overwrite).
+    // On all other events: reuse the pending values cached during StartExtractingMetadata.
     const eventContext = event.payload.event_context;
 
-    if (event.payload.event_type === EventType.StartExtractingData) {
+    if (event.payload.event_type === EventType.StartExtractingMetadata) {
       const timeFields = [
         {
           source: 'extraction_start_time',
@@ -127,7 +127,7 @@ export async function createAdapterState<ConnectorState>({
         }
       }
     } else {
-      // Non-StartExtractingData events: reuse pending values from state
+      // Non-StartExtractingMetadata events: reuse pending values from state
       if (as.state.pendingWorkersOldest) {
         eventContext.extract_from = as.state.pendingWorkersOldest;
         console.log(

--- a/src/state/state.ts
+++ b/src/state/state.ts
@@ -134,7 +134,7 @@ export async function createAdapterState<ConnectorState>({
           `Reusing pendingWorkersOldest as extract_from: ${as.state.pendingWorkersOldest}.`
         );
       } else {
-        console.warn(
+        console.log(
           'pendingWorkersOldest is not set in state. extract_from will not be populated for this invocation.'
         );
       }
@@ -144,7 +144,7 @@ export async function createAdapterState<ConnectorState>({
           `Reusing pendingWorkersNewest as extract_to: ${as.state.pendingWorkersNewest}.`
         );
       } else {
-        console.warn(
+        console.log(
           'pendingWorkersNewest is not set in state. extract_to will not be populated for this invocation.'
         );
       }

--- a/src/state/state.ts
+++ b/src/state/state.ts
@@ -126,6 +126,11 @@ export async function createAdapterState<ConnectorState>({
           }
         }
       }
+
+      // Remove raw platform fields from event context so SDK users only see
+      // the resolved extract_from / extract_to strings.
+      delete eventContext.extraction_start_time;
+      delete eventContext.extraction_end_time;
     } else {
       // Non-StartExtractingMetadata events: reuse pending values from state
       if (as.state.pendingWorkersOldest) {

--- a/src/state/state.ts
+++ b/src/state/state.ts
@@ -126,11 +126,6 @@ export async function createAdapterState<ConnectorState>({
           }
         }
       }
-
-      // Remove raw platform fields from event context so SDK users only see
-      // the resolved extract_from / extract_to strings.
-      delete eventContext.extraction_start_time;
-      delete eventContext.extraction_end_time;
     } else {
       // Non-StartExtractingMetadata events: reuse pending values from state
       if (as.state.pendingWorkersOldest) {


### PR DESCRIPTION
## Description

<!--
    A brief description of what the PR does/changes.
    Use active voice and present tense, e.g., This PR fixes ...
-->
Currently the extraction time calculation is being done in `StartExtractingData`, but should be in the `StartExtractingMetadata`, so change this.
## Connected Issues

<!--
    DevRev issue(s) full link(s) (e.g. https://app.devrev.ai/devrev/works/ISS-123).
-->
- [#ISS-283963](https://app.devrev.ai/devrev/works/ISS-283963)
## Checklist

- [x] Tests added/updated and ran with `npm run test` OR no tests needed.
- [x] Ran backwards compatibility tests with `npm run test:backwards-compatibility`.
- [x] Code formatted and checked with `npm run lint`.
- [x] Tested airdrop-template linked to this PR.
- [x] Documentation updated and provided a link to PR / new docs OR no docs needed.
