### PR TITLE
Bump axios to 1.15.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@devrev/ts-adaas",
-  "version": "1.19.3",
+  "version": "1.19.4-beta.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@devrev/ts-adaas",
-      "version": "1.19.3",
+      "version": "1.19.4-beta.0",
       "license": "ISC",
       "dependencies": {
         "@devrev/typescript-sdk": "^1.1.59",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@devrev/typescript-sdk": "^1.1.59",
-        "axios": "^1.15.0",
+        "axios": "^1.15.2",
         "axios-retry": "^4.5.0",
         "form-data": "^4.0.4",
         "js-jsonl": "^1.1.1",
@@ -2143,9 +2143,9 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
-      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
+      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "@devrev/typescript-sdk": "^1.1.59",
-    "axios": "^1.15.0",
+    "axios": "^1.15.2",
     "axios-retry": "^4.5.0",
     "form-data": "^4.0.4",
     "js-jsonl": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@devrev/ts-adaas",
-  "version": "1.19.3",
+  "version": "1.19.4-beta.0",
   "description": "Typescript library containing the ADaaS(AirDrop as a Service) control protocol.",
   "type": "commonjs",
   "main": "./dist/index.js",

--- a/src/attachments-streaming/attachments-streaming-pool.test.ts
+++ b/src/attachments-streaming/attachments-streaming-pool.test.ts
@@ -5,11 +5,6 @@ import {
   ProcessAttachmentReturnType,
 } from '../types';
 import { AttachmentsStreamingPool } from './attachments-streaming-pool';
-import {
-  runWithSdkLogContext,
-  runWithUserLogContext,
-  getSdkLogContextValue,
-} from '../logger/logger.context';
 
 // Mock types
 interface TestState {
@@ -656,7 +651,6 @@ describe(AttachmentsStreamingPool.name, () => {
     });
 
     it('should process user stream callback correctly while maintaining context isolation', async () => {
-      let userCallbackContextId: string | undefined;
       let userCallbackExecuted = false;
 
       // Mock stream to capture context info
@@ -665,10 +659,10 @@ describe(AttachmentsStreamingPool.name, () => {
         .mockImplementation(async () => {
           userCallbackExecuted = true;
           // Record that the callback executed
-          return {
+          return Promise.resolve({
             httpStream: undefined,
             error: undefined,
-          };
+          });
         });
 
       mockAdapter.processAttachment.mockImplementation(

--- a/src/multithreading/worker-adapter/worker-adapter.ts
+++ b/src/multithreading/worker-adapter/worker-adapter.ts
@@ -913,11 +913,10 @@ export class WorkerAdapter<ConnectorState> {
       if (httpStream) {
         const fileType =
           attachment.content_type ||
-          httpStream.headers['content-type'] ||
+          httpStream.headers['content-type']?.toString() ||
           'application/octet-stream';
-        const fileSize = httpStream.headers['content-length']
-          ? parseInt(httpStream.headers['content-length'])
-          : undefined;
+        const contentLength = httpStream.headers['content-length']?.toString();
+        const fileSize = contentLength ? parseInt(contentLength) : undefined;
 
         // Get upload URL
         const { error: artifactUrlError, response: artifactUrlResponse } =


### PR DESCRIPTION
## Description

<!--
    A brief description of what the PR does/changes.
    Use active voice and present tense, e.g., This PR fixes ...
-->
This PR bumps the axios version to 1.15.2 to get rid of critical and medium vulnerabilities introduced through 1.15.0.

## Connected Issues

<!--
    DevRev issue(s) full link(s) (e.g. https://app.devrev.ai/devrev/works/ISS-123).
-->
https://app.devrev.ai/devrev/works/ISS-295294

## Checklist

- [x] Tests added/updated and ran with `npm run test` OR no tests needed.
- [x] Ran backwards compatibility tests with `npm run test:backwards-compatibility`.
- [x] Code formatted and checked with `npm run lint`.
- [x] Tested airdrop-template linked to this PR.
- [x] Documentation updated and provided a link to PR / new docs OR no docs needed.
