### PR TITLE
fix(worker-adapter): use plural 'attachments' item_type in attachment LoaderReport

### DIFF
--- a/src/multithreading/worker-adapter/worker-adapter.loading.test.ts
+++ b/src/multithreading/worker-adapter/worker-adapter.loading.test.ts
@@ -678,7 +678,7 @@ describe(`${WorkerAdapter.name}.loadAttachment`, () => {
     });
 
     // Assert
-    expect(result.report?.item_type).toBe('attachment');
+    expect(result.report?.item_type).toBe('attachments');
     expect(result.report?.[ActionType.CREATED]).toBe(1);
   });
 

--- a/src/multithreading/worker-adapter/worker-adapter.ts
+++ b/src/multithreading/worker-adapter/worker-adapter.ts
@@ -1068,7 +1068,7 @@ export class WorkerAdapter<ConnectorState> {
 
         return {
           report: {
-            item_type: 'attachment',
+            item_type: 'attachments',
             [ActionType.CREATED]: 1,
           },
         };
@@ -1076,7 +1076,7 @@ export class WorkerAdapter<ConnectorState> {
         console.warn('Failed to create attachment in external system', error);
         return {
           report: {
-            item_type: 'attachment',
+            item_type: 'attachments',
             [ActionType.FAILED]: 1,
           },
         };


### PR DESCRIPTION
## Summary

`WorkerAdapter.loadAttachment` emitted `item_type: 'attachment'` (singular) in its `LoaderReport`, while every other producer and consumer of the sync report uses `'attachments'` (plural):

- DevRev platform's `source_items[*].type` for attachment batches
- Native connectors (e.g., Jira) reporting attachment counts
- E2E verifier entity-type mappings (`Artifact → "attachments"`, `Attachment → "attachments"`)

As a result, destination-report count verification for **reverse-sync attachments via any ts-adaas-based connector** (asana, azure-boards, freshdesk variants) failed with `invalid_report_created_count` — the destination side reported `attachment: N` while the verifier looked up `attachments`, found 0, and flagged a mismatch despite attachments being created successfully in the external system.

The fix aligns the loader report with the rest of the platform. Diff is 3 lines total.

## Root cause

```ts
// worker-adapter.ts: loadAttachment
return {
  report: {
-    item_type: 'attachment',   // drift vs the rest of the platform
+    item_type: 'attachments',  // matches source_items, native connectors, E2E
    [ActionType.CREATED]: 1,
  },
};
```

Same change applied to the FAILED branch at line 1079.

## Scope / non-changes

Intentionally **not** changed:

- `supportedItemTypes: ['attachment']` at `worker-adapter.ts:588` — this is the filter applied against `stats_file[*].item_type` written by the platform upstream. It is a **separate semantic channel** (routing key for finding attachment batches to load), not telemetry. Changing it without a coordinated platform change would break attachment loading.
- `FileToLoad.itemType: 'attachment'` test fixtures (lines 428, 495, 597) — same reason; they represent the stats-file routing key, not a report.

## Customer impact

Downstream consumers of `@devrev/ts-adaas` do not read `report.item_type` themselves — each forwards the SDK's `reports` array to `adapter.emit(LoaderEventType.AttachmentLoadingDone, { reports, processed_files })`. Only the platform + E2E verifiers consume it, both of which already expect the plural form. No connector code needs to change.

Evidence: `airdrop-asana-snap-in`, `airdrop-asana-snap-in-internal`, `airdrop-azure-boards-snap-in`, `airdrop-filterable-freshdesk-snap-in`, `airdrop-freshdesk-snap-in`, `airdrop-freshdesk-import-snap-in`, and `airdrop-template` all just pass the reports array straight through.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run test` — 593/593 passing (1 assertion updated in `worker-adapter.loading.test.ts:681` to match the new plural value; other tests in the file reference `filesToLoad.itemType` which is the routing key, not the report, and remain unchanged)
- [x] `npm run build` — clean
- [x] **End-to-end validation**: confirmed the same fix applied as a normalization shim in `airdrop-e2e-test`'s verifier made `asana_basic_reverse` pass end-to-end on qa (reverse-attachment count verification is now green: `destination report created count = 2, source state count = 2`). This PR moves that fix upstream.
- [ ] CI `test:backwards-compatibility` — expected to pass without fixture updates (the backwards-compat suite asserts API *shape* via `@microsoft/api-extractor`, not runtime string values; `LoaderReport.item_type: string` is unchanged).
- [ ] CI `test:slow`

## Follow-ups (not in this PR)

- Once this PR is merged and published, bump `@devrev/ts-adaas` in `airdrop-asana-snap-in-internal` (currently pinned to 1.19.4).
- Remove the temporary `normalizeReportItemType` shim in `airdrop-e2e-test/internal/connector/verifiers.go` once all consumers are on the new SDK.
- `package.json` version bump left for the release manager.