### PR TITLE
feat: add `progress_data` to `worker_metadata`

### DIFF
--- a/src/common/control-protocol.test.ts
+++ b/src/common/control-protocol.test.ts
@@ -1,0 +1,173 @@
+import { axiosClient } from '../http/axios-client-internal';
+import { createAxiosResponse } from '../tests/test-helpers';
+import { createMockEvent } from './test-utils';
+import { emit } from './control-protocol';
+import { EventType, ExtractorEventType } from '../types/extraction';
+import { LoaderEventType } from '../types/loading';
+
+jest.mock('../http/axios-client-internal');
+
+const mockedAxiosClient = jest.mocked(axiosClient);
+
+describe('control-protocol.emit', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedAxiosClient.post.mockResolvedValue(createAxiosResponse());
+  });
+
+  it.each([
+    {
+      title: 'extractor events',
+      inputEventType: EventType.StartExtractingData,
+      outputEventType: ExtractorEventType.DataExtractionProgress,
+    },
+    {
+      title: 'loader events',
+      inputEventType: EventType.StartLoadingData,
+      outputEventType: LoaderEventType.DataLoadingProgress,
+    },
+    {
+      title: 'unknown events',
+      inputEventType: EventType.StartExtractingData,
+      outputEventType: 'SOME_UNKNOWN_EVENT' as ExtractorEventType,
+    },
+  ])(
+    'sets state dates from event context for $title',
+    async ({ inputEventType, outputEventType }) => {
+      const event = createMockEvent(undefined, {
+        payload: {
+          event_type: inputEventType,
+          event_context: {
+            extract_from: '2024-01-01T00:00:00.000Z',
+            extract_to: '2024-06-01T00:00:00.000Z',
+          },
+        },
+      });
+
+      await emit({
+        event,
+        eventType: outputEventType,
+      });
+
+      expect(mockedAxiosClient.post).toHaveBeenCalledTimes(1);
+
+      const [, body, config] = mockedAxiosClient.post.mock.calls[0] as [
+        string,
+        {
+          event_type: string;
+          event_context: {
+            extract_from?: string;
+            extract_to?: string;
+          };
+          worker_metadata: Record<string, unknown>;
+        },
+        { headers: Record<string, string> }
+      ];
+
+      expect(body).toMatchObject({
+        event_type: outputEventType,
+        event_context: expect.objectContaining({
+          extract_from: '2024-01-01T00:00:00.000Z',
+          extract_to: '2024-06-01T00:00:00.000Z',
+        }),
+        worker_metadata: expect.objectContaining({
+          oldest_state_date: '2024-01-01T00:00:00.000Z',
+          newest_state_date: '2024-06-01T00:00:00.000Z',
+        }),
+      });
+
+      expect(config).toEqual(
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            'X-DevRev-Client-Version': expect.any(String),
+          }),
+        })
+      );
+    }
+  );
+
+  it.each([
+    {
+      title: 'only extract_from is set',
+      extractFrom: '2024-01-01T00:00:00.000Z',
+      extractTo: undefined,
+    },
+    {
+      title: 'only extract_to is set',
+      extractFrom: undefined,
+      extractTo: '2024-06-01T00:00:00.000Z',
+    },
+    {
+      title: 'neither extract_from nor extract_to is set',
+      extractFrom: undefined,
+      extractTo: undefined,
+    },
+  ])(
+    'handles state-date absence when $title',
+    async ({ extractFrom, extractTo }) => {
+      const event = createMockEvent(undefined, {
+        payload: {
+          event_type: EventType.StartExtractingData,
+          event_context: {
+            extract_from: extractFrom,
+            extract_to: extractTo,
+          },
+        },
+      });
+
+      await emit({
+        event,
+        eventType: ExtractorEventType.DataExtractionProgress,
+      });
+
+      const [, body] = mockedAxiosClient.post.mock.calls[0] as [
+        string,
+        {
+          worker_metadata: Record<string, unknown>;
+        },
+        unknown
+      ];
+      const workerMetadata = body.worker_metadata;
+
+      expect(workerMetadata.oldest_state_date).toBe(extractFrom);
+      expect(workerMetadata.newest_state_date).toBe(extractTo);
+    }
+  );
+
+  it('overrides caller-provided worker_metadata state dates', async () => {
+    const event = createMockEvent(undefined, {
+      payload: {
+        event_type: EventType.StartExtractingData,
+        event_context: {
+          extract_from: '2024-01-01T00:00:00.000Z',
+          extract_to: '2024-06-01T00:00:00.000Z',
+        },
+      },
+    });
+
+    await emit({
+      event,
+      eventType: ExtractorEventType.DataExtractionProgress,
+      worker_metadata: {
+        item_type: 'tasks',
+        oldest_state_date: 'should-be-overwritten',
+        newest_state_date: 'should-be-overwritten',
+      },
+    });
+
+    const [, body] = mockedAxiosClient.post.mock.calls[0] as [
+      string,
+      {
+        worker_metadata: Record<string, unknown>;
+      },
+      unknown
+    ];
+    expect(body.worker_metadata).toEqual(
+      expect.objectContaining({
+        item_type: 'tasks',
+        oldest_state_date: '2024-01-01T00:00:00.000Z',
+        newest_state_date: '2024-06-01T00:00:00.000Z',
+      })
+    );
+  });
+});

--- a/src/common/control-protocol.ts
+++ b/src/common/control-protocol.ts
@@ -15,12 +15,16 @@ export interface EmitInterface {
   event: AirdropEvent;
   eventType: ExtractorEventType | LoaderEventType;
   data?: EventData;
+  worker_metadata?: {
+    progress_data: Record<string, { min: number; max: number }>;
+  };
 }
 
 export const emit = async ({
   event,
   eventType,
   data,
+  worker_metadata,
 }: EmitInterface): Promise<AxiosResponse> => {
   // Translate outgoing event type to ensure we always send new event types
   // TODO: Remove when the old types are completely phased out
@@ -33,6 +37,7 @@ export const emit = async ({
       ...data,
     },
     worker_metadata: {
+      ...worker_metadata,
       adaas_library_version: LIBRARY_VERSION,
     },
   };

--- a/src/common/control-protocol.ts
+++ b/src/common/control-protocol.ts
@@ -12,8 +12,8 @@ import { LIBRARY_VERSION } from './constants';
 import { translateOutgoingEventType } from './event-type-translation';
 
 export interface DateRange {
-  oldest: number;
-  newest: number;
+  oldest?: string;
+  newest?: string;
 }
 
 export interface ProgressData {

--- a/src/common/control-protocol.ts
+++ b/src/common/control-protocol.ts
@@ -6,29 +6,17 @@ import {
   ExtractorEvent,
   ExtractorEventType,
   LoaderEvent,
+  WorkerMetadata,
 } from '../types/extraction';
 import { LoaderEventType } from '../types/loading';
 import { LIBRARY_VERSION } from './constants';
 import { translateOutgoingEventType } from './event-type-translation';
 
-export interface DateRange {
-  oldest?: string;
-  newest?: string;
-}
-
-export interface ProgressData {
-  item_type?: string;
-  creationDate?: DateRange;
-  modifiedDate?: DateRange;
-}
-
 export interface EmitInterface {
   event: AirdropEvent;
   eventType: ExtractorEventType | LoaderEventType;
   data?: EventData;
-  worker_metadata?: {
-    progress_data: ProgressData;
-  };
+  worker_metadata?: WorkerMetadata;
 }
 
 export const emit = async ({
@@ -49,6 +37,8 @@ export const emit = async ({
     },
     worker_metadata: {
       ...worker_metadata,
+      newest_state_date: event.payload.event_context.extract_to,
+      oldest_state_date: event.payload.event_context.extract_from,
       adaas_library_version: LIBRARY_VERSION,
     },
   };

--- a/src/common/control-protocol.ts
+++ b/src/common/control-protocol.ts
@@ -11,12 +11,23 @@ import { LoaderEventType } from '../types/loading';
 import { LIBRARY_VERSION } from './constants';
 import { translateOutgoingEventType } from './event-type-translation';
 
+export interface DateRange {
+  oldest: number;
+  newest: number;
+}
+
+export interface ProgressData {
+  item_type?: string;
+  creationDate?: DateRange;
+  modifiedDate?: DateRange;
+}
+
 export interface EmitInterface {
   event: AirdropEvent;
   eventType: ExtractorEventType | LoaderEventType;
   data?: EventData;
   worker_metadata?: {
-    progress_data: Record<string, { min: number; max: number }>;
+    progress_data: ProgressData;
   };
 }
 

--- a/src/multithreading/worker-adapter/worker-adapter.emit.test.ts
+++ b/src/multithreading/worker-adapter/worker-adapter.emit.test.ts
@@ -319,7 +319,7 @@ describe(`${WorkerAdapter.name}.emit`, () => {
   });
 });
 
-describe(`${WorkerAdapter.name}.emit — progress_data`, () => {
+describe(`${WorkerAdapter.name}.emit — worker_metadata`, () => {
   let adapter: WorkerAdapter<TestState>;
 
   beforeEach(() => {
@@ -352,20 +352,22 @@ describe(`${WorkerAdapter.name}.emit — progress_data`, () => {
     adapterInstance['lastExtractedItemType'] = lastExtractedItemType;
   }
 
-  it('should emit flat progress_data for the latest extracted item type only', async () => {
+  it('should emit flat worker_metadata for the latest extracted item type only', async () => {
     setupRepos(adapter, 'tasks');
 
     await adapter.emit(ExtractorEventType.DataExtractionProgress);
 
     const { emit: mockEmit } = require('../../common/control-protocol');
-    expect(mockEmit.mock.calls[0][0].worker_metadata.progress_data).toEqual({
+    expect(mockEmit.mock.calls[0][0].worker_metadata).toEqual({
       item_type: 'tasks',
-      creationDate: { oldest: iso(300), newest: iso(400) },
-      modifiedDate: { oldest: iso(350), newest: iso(450) },
+      oldest_created_date: iso(300),
+      newest_created_date: iso(400),
+      oldest_modified_date: iso(350),
+      newest_modified_date: iso(450),
     });
   });
 
-  it('should omit unset RFC3339 bounds from progress_data', async () => {
+  it('should omit unset RFC3339 bounds from worker_metadata', async () => {
     adapter['repos'] = [
       {
         itemType: 'tasks',
@@ -380,40 +382,34 @@ describe(`${WorkerAdapter.name}.emit — progress_data`, () => {
     await adapter.emit(ExtractorEventType.DataExtractionProgress);
 
     const { emit: mockEmit } = require('../../common/control-protocol');
-    expect(mockEmit.mock.calls[0][0].worker_metadata.progress_data).toEqual({
+    expect(mockEmit.mock.calls[0][0].worker_metadata).toEqual({
       item_type: 'tasks',
     });
   });
 
-  it('should send empty progress_data when no item type has been extracted', async () => {
+  it('should send empty worker_metadata when no item type has been extracted', async () => {
     await adapter.emit(ExtractorEventType.DataExtractionProgress);
 
     const { emit: mockEmit } = require('../../common/control-protocol');
-    expect(mockEmit.mock.calls[0][0].worker_metadata.progress_data).toEqual(
-      {}
-    );
+    expect(mockEmit.mock.calls[0][0].worker_metadata).toEqual({});
   });
 
-  it('should send empty progress_data for loader events', async () => {
+  it('should send empty worker_metadata for loader events', async () => {
     setupRepos(adapter, 'tasks');
 
     await adapter.emit(LoaderEventType.DataLoadingProgress);
 
     const { emit: mockEmit } = require('../../common/control-protocol');
-    expect(mockEmit.mock.calls[0][0].worker_metadata.progress_data).toEqual(
-      {}
-    );
+    expect(mockEmit.mock.calls[0][0].worker_metadata).toEqual({});
   });
 
-  it('should send empty progress_data for non-progress extraction events', async () => {
+  it('should send empty worker_metadata for non-progress extraction events', async () => {
     setupRepos(adapter, 'tasks');
 
     await adapter.emit(ExtractorEventType.DataExtractionError);
 
     const { emit: mockEmit } = require('../../common/control-protocol');
-    expect(mockEmit.mock.calls[0][0].worker_metadata.progress_data).toEqual(
-      {}
-    );
+    expect(mockEmit.mock.calls[0][0].worker_metadata).toEqual({});
   });
 });
 

--- a/src/multithreading/worker-adapter/worker-adapter.emit.test.ts
+++ b/src/multithreading/worker-adapter/worker-adapter.emit.test.ts
@@ -317,6 +317,84 @@ describe(`${WorkerAdapter.name}.emit`, () => {
   });
 });
 
+describe(`${WorkerAdapter.name}.emit — progress_data`, () => {
+  let adapter: WorkerAdapter<TestState>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    ({ adapter } = makeAdapter());
+    adapter['adapterState'].postState = jest.fn().mockResolvedValue(undefined);
+    adapter.uploadAllRepos = jest.fn().mockResolvedValue(undefined);
+  });
+
+  function setupRepos(
+    adapterInstance: WorkerAdapter<TestState>,
+    lastExtractedItemType: string
+  ) {
+    adapterInstance['repos'] = [
+      {
+        itemType: 'issues',
+        dateRanges: {
+          creationDate: { oldest: 100, newest: 200 },
+          modifiedDate: { oldest: 150, newest: 250 },
+        },
+      },
+      {
+        itemType: 'tasks',
+        dateRanges: {
+          creationDate: { oldest: 300, newest: 400 },
+          modifiedDate: { oldest: 350, newest: 450 },
+        },
+      },
+    ] as never;
+    adapterInstance['lastExtractedItemType'] = lastExtractedItemType;
+  }
+
+  it('should emit flat progress_data for the latest extracted item type only', async () => {
+    setupRepos(adapter, 'tasks');
+
+    await adapter.emit(ExtractorEventType.DataExtractionProgress);
+
+    const { emit: mockEmit } = require('../../common/control-protocol');
+    expect(mockEmit.mock.calls[0][0].worker_metadata.progress_data).toEqual({
+      item_type: 'tasks',
+      creationDate: { oldest: 300, newest: 400 },
+      modifiedDate: { oldest: 350, newest: 450 },
+    });
+  });
+
+  it('should send empty progress_data when no item type has been extracted', async () => {
+    await adapter.emit(ExtractorEventType.DataExtractionProgress);
+
+    const { emit: mockEmit } = require('../../common/control-protocol');
+    expect(mockEmit.mock.calls[0][0].worker_metadata.progress_data).toEqual(
+      {}
+    );
+  });
+
+  it('should send empty progress_data for loader events', async () => {
+    setupRepos(adapter, 'tasks');
+
+    await adapter.emit(LoaderEventType.DataLoadingProgress);
+
+    const { emit: mockEmit } = require('../../common/control-protocol');
+    expect(mockEmit.mock.calls[0][0].worker_metadata.progress_data).toEqual(
+      {}
+    );
+  });
+
+  it('should send empty progress_data for non-progress extraction events', async () => {
+    setupRepos(adapter, 'tasks');
+
+    await adapter.emit(ExtractorEventType.DataExtractionError);
+
+    const { emit: mockEmit } = require('../../common/control-protocol');
+    expect(mockEmit.mock.calls[0][0].worker_metadata.progress_data).toEqual(
+      {}
+    );
+  });
+});
+
 describe(`${WorkerAdapter.name}.emit — ExternalSyncUnitExtractionDone legacy path`, () => {
   it('should upload ESUs via a repo and strip external_sync_units from the emitted payload', async () => {
     // Arrange

--- a/src/multithreading/worker-adapter/worker-adapter.emit.test.ts
+++ b/src/multithreading/worker-adapter/worker-adapter.emit.test.ts
@@ -61,6 +61,8 @@ function makeAdapter(eventType: EventType = EventType.StartExtractingData): {
   return { adapter, event, adapterState };
 }
 
+const iso = (ms: number) => new Date(ms).toISOString();
+
 describe(`${WorkerAdapter.name}.emit`, () => {
   let adapter: WorkerAdapter<TestState>;
   let mockPostMessage: jest.Mock;
@@ -358,8 +360,28 @@ describe(`${WorkerAdapter.name}.emit — progress_data`, () => {
     const { emit: mockEmit } = require('../../common/control-protocol');
     expect(mockEmit.mock.calls[0][0].worker_metadata.progress_data).toEqual({
       item_type: 'tasks',
-      creationDate: { oldest: 300, newest: 400 },
-      modifiedDate: { oldest: 350, newest: 450 },
+      creationDate: { oldest: iso(300), newest: iso(400) },
+      modifiedDate: { oldest: iso(350), newest: iso(450) },
+    });
+  });
+
+  it('should omit unset RFC3339 bounds from progress_data', async () => {
+    adapter['repos'] = [
+      {
+        itemType: 'tasks',
+        dateRanges: {
+          creationDate: { oldest: 0, newest: 0 },
+          modifiedDate: { oldest: 0, newest: 0 },
+        },
+      },
+    ] as never;
+    adapter['lastExtractedItemType'] = 'tasks';
+
+    await adapter.emit(ExtractorEventType.DataExtractionProgress);
+
+    const { emit: mockEmit } = require('../../common/control-protocol');
+    expect(mockEmit.mock.calls[0][0].worker_metadata.progress_data).toEqual({
+      item_type: 'tasks',
     });
   });
 

--- a/src/multithreading/worker-adapter/worker-adapter.ts
+++ b/src/multithreading/worker-adapter/worker-adapter.ts
@@ -7,7 +7,7 @@ import {
   SSOR_ATTACHMENT,
   STATELESS_EVENT_TYPES,
 } from '../../common/constants';
-import { emit } from '../../common/control-protocol';
+import { emit, ProgressData } from '../../common/control-protocol';
 import {
   addReportToLoaderReport,
   getFilesToLoad,
@@ -97,6 +97,7 @@ export class WorkerAdapter<ConnectorState> {
   private adapterState: State<ConnectorState>;
   private _artifacts: Artifact[];
   private repos: Repo[] = [];
+  private lastExtractedItemType?: string;
   private currentEventDataLength: number = 0;
 
   // Loader
@@ -176,6 +177,8 @@ export class WorkerAdapter<ConnectorState> {
         itemType: repo.itemType,
         ...(shouldNormalize && { normalize: repo.normalize }),
         onUpload: (artifact: Artifact) => {
+          this.lastExtractedItemType = repo.itemType;
+
           // We need to store artifacts ids in state for later use when streaming attachments
           if (repo.itemType === AirSyncDefaultItemTypes.ATTACHMENTS) {
             this.state.toDevRev?.attachmentsMetadata.artifactIds.push(
@@ -366,7 +369,7 @@ export class WorkerAdapter<ConnectorState> {
           newEventType as LoaderEventType
         );
 
-        const itemTimestamps: Record<string, { min: number; max: number }> = {};
+        const progress_data: ProgressData = {};
         if (
           isExtractionEvent &&
           (newEventType == ExtractorEventType.DataExtractionDone ||
@@ -374,8 +377,13 @@ export class WorkerAdapter<ConnectorState> {
             newEventType == ExtractorEventType.AttachmentExtractionDone ||
             newEventType == ExtractorEventType.AttachmentExtractionProgress)
         ) {
-          for (const repo of this.repos) {
-            itemTimestamps[repo.itemType] = repo.itemTimestamps;
+          const repo = this.lastExtractedItemType
+            ? this.repos.find((r) => r.itemType === this.lastExtractedItemType)
+            : undefined;
+          if (repo) {
+            progress_data.item_type = repo.itemType;
+            progress_data.creationDate = repo.dateRanges.creationDate;
+            progress_data.modifiedDate = repo.dateRanges.modifiedDate;
           }
         }
 
@@ -389,7 +397,7 @@ export class WorkerAdapter<ConnectorState> {
               ? { reports: this.reports, processed_files: this.processedFiles }
               : {}),
           },
-          worker_metadata: { progress_data: itemTimestamps },
+          worker_metadata: { progress_data },
         });
 
         const message: WorkerMessageEmitted = {

--- a/src/multithreading/worker-adapter/worker-adapter.ts
+++ b/src/multithreading/worker-adapter/worker-adapter.ts
@@ -61,6 +61,31 @@ import { Artifact, SsorAttachment } from '../../uploader/uploader.interfaces';
 import { translateOutgoingEventType } from '../../common/event-type-translation';
 import { truncateMessage } from '../../common/helpers';
 
+function toRfc3339Timestamp(ms: number): string | undefined {
+  if (!Number.isFinite(ms) || ms === 0) {
+    return undefined;
+  }
+
+  return new Date(ms).toISOString();
+}
+
+function toRfc3339DateRange(range: {
+  oldest: number;
+  newest: number;
+}): ProgressData['creationDate'] {
+  const oldest = toRfc3339Timestamp(range.oldest);
+  const newest = toRfc3339Timestamp(range.newest);
+
+  if (!oldest && !newest) {
+    return undefined;
+  }
+
+  return {
+    ...(oldest ? { oldest } : {}),
+    ...(newest ? { newest } : {}),
+  };
+}
+
 export function createWorkerAdapter<ConnectorState>({
   event,
   adapterState,
@@ -382,8 +407,20 @@ export class WorkerAdapter<ConnectorState> {
             : undefined;
           if (repo) {
             progress_data.item_type = repo.itemType;
-            progress_data.creationDate = repo.dateRanges.creationDate;
-            progress_data.modifiedDate = repo.dateRanges.modifiedDate;
+            progress_data.creationDate = toRfc3339DateRange(
+              repo.dateRanges.creationDate
+            );
+            progress_data.modifiedDate = toRfc3339DateRange(
+              repo.dateRanges.modifiedDate
+            );
+
+            if (!progress_data.creationDate) {
+              delete progress_data.creationDate;
+            }
+
+            if (!progress_data.modifiedDate) {
+              delete progress_data.modifiedDate;
+            }
           }
         }
 

--- a/src/multithreading/worker-adapter/worker-adapter.ts
+++ b/src/multithreading/worker-adapter/worker-adapter.ts
@@ -7,7 +7,7 @@ import {
   SSOR_ATTACHMENT,
   STATELESS_EVENT_TYPES,
 } from '../../common/constants';
-import { emit, ProgressData } from '../../common/control-protocol';
+import { emit } from '../../common/control-protocol';
 import {
   addReportToLoaderReport,
   getFilesToLoad,
@@ -67,23 +67,6 @@ function toRfc3339Timestamp(ms: number): string | undefined {
   }
 
   return new Date(ms).toISOString();
-}
-
-function toRfc3339DateRange(range: {
-  oldest: number;
-  newest: number;
-}): ProgressData['creationDate'] {
-  const oldest = toRfc3339Timestamp(range.oldest);
-  const newest = toRfc3339Timestamp(range.newest);
-
-  if (!oldest && !newest) {
-    return undefined;
-  }
-
-  return {
-    ...(oldest ? { oldest } : {}),
-    ...(newest ? { newest } : {}),
-  };
 }
 
 export function createWorkerAdapter<ConnectorState>({
@@ -394,7 +377,19 @@ export class WorkerAdapter<ConnectorState> {
           newEventType as LoaderEventType
         );
 
-        const progress_data: ProgressData = {};
+        const progress_data: {
+          // Last extracted item type statistics
+          item_type?: string;
+          oldest_created_date?: string;
+          newest_created_date?: string;
+          oldest_modified_date?: string;
+          newest_modified_date?: string;
+
+          // Calculated time ranges in absolute times
+          oldest_state_date?: string;
+          newest_state_date?: string;
+        } = {};
+
         if (
           isExtractionEvent &&
           (newEventType == ExtractorEventType.DataExtractionDone ||
@@ -407,20 +402,18 @@ export class WorkerAdapter<ConnectorState> {
             : undefined;
           if (repo) {
             progress_data.item_type = repo.itemType;
-            progress_data.creationDate = toRfc3339DateRange(
-              repo.dateRanges.creationDate
+            progress_data.newest_created_date = toRfc3339Timestamp(
+              repo.dateRanges.creationDate.newest
             );
-            progress_data.modifiedDate = toRfc3339DateRange(
-              repo.dateRanges.modifiedDate
+            progress_data.oldest_created_date = toRfc3339Timestamp(
+              repo.dateRanges.creationDate.oldest
             );
-
-            if (!progress_data.creationDate) {
-              delete progress_data.creationDate;
-            }
-
-            if (!progress_data.modifiedDate) {
-              delete progress_data.modifiedDate;
-            }
+            progress_data.newest_modified_date = toRfc3339Timestamp(
+              repo.dateRanges.modifiedDate.newest
+            );
+            progress_data.oldest_modified_date = toRfc3339Timestamp(
+              repo.dateRanges.modifiedDate.oldest
+            );
           }
         }
 
@@ -434,7 +427,7 @@ export class WorkerAdapter<ConnectorState> {
               ? { reports: this.reports, processed_files: this.processedFiles }
               : {}),
           },
-          worker_metadata: { progress_data },
+          worker_metadata: { ...progress_data },
         });
 
         const message: WorkerMessageEmitted = {

--- a/src/multithreading/worker-adapter/worker-adapter.ts
+++ b/src/multithreading/worker-adapter/worker-adapter.ts
@@ -366,6 +366,19 @@ export class WorkerAdapter<ConnectorState> {
           newEventType as LoaderEventType
         );
 
+        const itemTimestamps: Record<string, { min: number; max: number }> = {};
+        if (
+          isExtractionEvent &&
+          (newEventType == ExtractorEventType.DataExtractionDone ||
+            newEventType == ExtractorEventType.DataExtractionProgress ||
+            newEventType == ExtractorEventType.AttachmentExtractionDone ||
+            newEventType == ExtractorEventType.AttachmentExtractionProgress)
+        ) {
+          for (const repo of this.repos) {
+            itemTimestamps[repo.itemType] = repo.itemTimestamps;
+          }
+        }
+
         await emit({
           eventType: newEventType,
           event: this.event,
@@ -376,6 +389,7 @@ export class WorkerAdapter<ConnectorState> {
               ? { reports: this.reports, processed_files: this.processedFiles }
               : {}),
           },
+          worker_metadata: { progress_data: itemTimestamps },
         });
 
         const message: WorkerMessageEmitted = {

--- a/src/repo/repo.interfaces.ts
+++ b/src/repo/repo.interfaces.ts
@@ -45,6 +45,7 @@ export interface NormalizedAttachment {
   inline?: boolean;
   content_type?: string;
   created_date?: string;
+  modified_date?: string;
 
   // This should be a string, but it was a number in the past. Due to backwards
   // compatibility we are keeping it also as a number.

--- a/src/repo/repo.interfaces.ts
+++ b/src/repo/repo.interfaces.ts
@@ -44,6 +44,7 @@ export interface NormalizedAttachment {
   author_id?: string;
   inline?: boolean;
   content_type?: string;
+  created_date?: string;
 
   // This should be a string, but it was a number in the past. Due to backwards
   // compatibility we are keeping it also as a number.

--- a/src/repo/repo.test.ts
+++ b/src/repo/repo.test.ts
@@ -3,12 +3,30 @@ import { createItems, normalizeItem } from '../tests/test-helpers';
 import { mockServer } from '../tests/jest.setup';
 import { createMockEvent } from '../common/test-utils';
 import { EventType } from '../types';
+import { NormalizedAttachment, NormalizedItem } from './repo.interfaces';
 import { Repo } from './repo';
 
 jest.mock('../tests/test-helpers', () => ({
   ...jest.requireActual('../tests/test-helpers'),
   normalizeItem: jest.fn(),
 }));
+
+const mockUploadFn = jest.fn().mockResolvedValue({
+  error: null,
+  artifact: { id: 'art-1', item_type: 'test', item_count: 0 },
+});
+
+jest.mock('../uploader/uploader', () => ({
+  Uploader: jest.fn().mockImplementation(() => ({
+    upload: mockUploadFn,
+  })),
+}));
+
+function itemWithDate(id: string, created_date: string): NormalizedItem {
+  return { id, created_date, modified_date: created_date, data: {} };
+}
+
+const ts = (iso: string) => new Date(iso).getTime();
 
 describe(Repo.name, () => {
   let repo: Repo;
@@ -226,6 +244,135 @@ describe(Repo.name, () => {
 
       // Assert
       expect(repo.getItems().length).toBe(5);
+    });
+  });
+
+  describe('itemTimestamps', () => {
+    beforeEach(() => {
+      mockUploadFn.mockResolvedValue({
+        error: null,
+        artifact: { id: 'art-1', item_type: 'test', item_count: 0 },
+      });
+    });
+
+    it('should track min and max created_date from a single upload batch', async () => {
+      await repo.upload([
+        itemWithDate('1', '2023-06-15T12:00:00.000Z'),
+        itemWithDate('2', '2020-01-01T00:00:00.000Z'),
+        itemWithDate('3', '2021-03-01T00:00:00.000Z'),
+      ]);
+
+      expect(repo.itemTimestamps.min).toBe(ts('2020-01-01T00:00:00.000Z'));
+      expect(repo.itemTimestamps.max).toBe(ts('2023-06-15T12:00:00.000Z'));
+    });
+
+    it('should skip items without created_date', async () => {
+      const attachmentWithoutDate: NormalizedAttachment = {
+        id: 'att-1',
+        url: 'https://example.com/file',
+        file_name: 'file.txt',
+        parent_id: 'parent-1',
+      };
+
+      await repo.upload([
+        itemWithDate('1', '2022-06-01T00:00:00.000Z'),
+        { id: '2', created_date: null, modified_date: '', data: {} },
+        { id: '3', modified_date: '', data: {} },
+        attachmentWithoutDate,
+      ]);
+
+      expect(repo.itemTimestamps.min).toBe(ts('2022-06-01T00:00:00.000Z'));
+      expect(repo.itemTimestamps.max).toBe(ts('2022-06-01T00:00:00.000Z'));
+    });
+
+    it('should leave timestamps at zero when no items have created_date', async () => {
+      await repo.upload([
+        { id: '1', modified_date: '', data: {} },
+        {
+          id: 'att-1',
+          url: 'https://example.com/file',
+          file_name: 'file.txt',
+          parent_id: 'parent-1',
+        },
+      ]);
+
+      expect(repo.itemTimestamps).toEqual({ min: 0, max: 0 });
+    });
+
+    it('should not update timestamps or call uploader on empty upload', async () => {
+      await repo.upload([]);
+
+      expect(repo.itemTimestamps).toEqual({ min: 0, max: 0 });
+      expect(mockUploadFn).not.toHaveBeenCalled();
+    });
+
+    it('should accumulate min and max across multiple upload batches via push', async () => {
+      repo = new Repo({
+        event: createMockEvent(mockServer.baseUrl, {
+          payload: { event_type: EventType.ExtractionDataStart },
+        }),
+        itemType: 'test_item_type',
+        onUpload: jest.fn(),
+        options: { batchSize: 3 },
+      });
+
+      const dates = [
+        '2020-01-01T00:00:00.000Z',
+        '2021-01-01T00:00:00.000Z',
+        '2022-01-01T00:00:00.000Z',
+        '2023-01-01T00:00:00.000Z',
+        '2024-06-01T00:00:00.000Z',
+        '2024-12-01T00:00:00.000Z',
+        '2024-12-31T00:00:00.000Z',
+      ];
+      const items = dates.map((created_date, index) =>
+        itemWithDate(String(index), created_date)
+      );
+
+      await repo.push(items);
+
+      expect(repo.getItems()).toHaveLength(1);
+      expect(repo.itemTimestamps.min).toBe(ts('2020-01-01T00:00:00.000Z'));
+      expect(repo.itemTimestamps.max).toBe(ts('2024-12-01T00:00:00.000Z'));
+
+      await repo.push([
+        itemWithDate('7', '2019-01-01T00:00:00.000Z'),
+        itemWithDate('8', '2025-01-01T00:00:00.000Z'),
+      ]);
+
+      expect(repo.getItems()).toHaveLength(0);
+      expect(repo.itemTimestamps.min).toBe(ts('2019-01-01T00:00:00.000Z'));
+      expect(repo.itemTimestamps.max).toBe(ts('2025-01-01T00:00:00.000Z'));
+    });
+
+    it('should extend min and max when subsequent batches have wider date range', async () => {
+      await repo.upload([
+        itemWithDate('1', '2022-06-01T00:00:00.000Z'),
+        itemWithDate('2', '2023-06-01T00:00:00.000Z'),
+      ]);
+
+      expect(repo.itemTimestamps.min).toBe(ts('2022-06-01T00:00:00.000Z'));
+      expect(repo.itemTimestamps.max).toBe(ts('2023-06-01T00:00:00.000Z'));
+
+      await repo.upload([
+        itemWithDate('3', '2020-01-01T00:00:00.000Z'),
+        itemWithDate('4', '2024-01-01T00:00:00.000Z'),
+      ]);
+
+      expect(repo.itemTimestamps.min).toBe(ts('2020-01-01T00:00:00.000Z'));
+      expect(repo.itemTimestamps.max).toBe(ts('2024-01-01T00:00:00.000Z'));
+    });
+
+    it('should update timestamps even when upload fails', async () => {
+      mockUploadFn.mockResolvedValueOnce({
+        error: new Error('fail'),
+        artifact: null,
+      });
+
+      await repo.upload([itemWithDate('1', '2022-01-01T00:00:00.000Z')]);
+
+      expect(repo.itemTimestamps.min).toBe(ts('2022-01-01T00:00:00.000Z'));
+      expect(repo.itemTimestamps.max).toBe(ts('2022-01-01T00:00:00.000Z'));
     });
   });
 });

--- a/src/repo/repo.test.ts
+++ b/src/repo/repo.test.ts
@@ -454,8 +454,16 @@ describe(Repo.name, () => {
 
     it('should track modified_date independently from created_date', async () => {
       await repo.upload([
-        itemWithDates('1', '2020-01-01T00:00:00.000Z', '2023-01-01T00:00:00.000Z'),
-        itemWithDates('2', '2024-01-01T00:00:00.000Z', '2021-06-01T00:00:00.000Z'),
+        itemWithDates(
+          '1',
+          '2020-01-01T00:00:00.000Z',
+          '2023-01-01T00:00:00.000Z'
+        ),
+        itemWithDates(
+          '2',
+          '2024-01-01T00:00:00.000Z',
+          '2021-06-01T00:00:00.000Z'
+        ),
       ]);
 
       expect(repo.dateRanges.creationDate.oldest).toBe(

--- a/src/repo/repo.test.ts
+++ b/src/repo/repo.test.ts
@@ -423,6 +423,35 @@ describe(Repo.name, () => {
       );
     });
 
+    it('should ignore invalid created_date and modified_date values', async () => {
+      await repo.upload([
+        {
+          id: '1',
+          created_date: 'not-a-date',
+          modified_date: 'still-not-a-date',
+          data: {},
+        },
+        itemWithDates(
+          '2',
+          '2022-01-01T00:00:00.000Z',
+          '2023-01-01T00:00:00.000Z'
+        ),
+      ]);
+
+      expect(repo.dateRanges.creationDate.oldest).toBe(
+        ts('2022-01-01T00:00:00.000Z')
+      );
+      expect(repo.dateRanges.creationDate.newest).toBe(
+        ts('2022-01-01T00:00:00.000Z')
+      );
+      expect(repo.dateRanges.modifiedDate.oldest).toBe(
+        ts('2023-01-01T00:00:00.000Z')
+      );
+      expect(repo.dateRanges.modifiedDate.newest).toBe(
+        ts('2023-01-01T00:00:00.000Z')
+      );
+    });
+
     it('should track modified_date independently from created_date', async () => {
       await repo.upload([
         itemWithDates('1', '2020-01-01T00:00:00.000Z', '2023-01-01T00:00:00.000Z'),

--- a/src/repo/repo.test.ts
+++ b/src/repo/repo.test.ts
@@ -26,6 +26,14 @@ function itemWithDate(id: string, created_date: string): NormalizedItem {
   return { id, created_date, modified_date: created_date, data: {} };
 }
 
+function itemWithDates(
+  id: string,
+  created_date: string,
+  modified_date: string
+): NormalizedItem {
+  return { id, created_date, modified_date, data: {} };
+}
+
 const ts = (iso: string) => new Date(iso).getTime();
 
 describe(Repo.name, () => {
@@ -247,7 +255,7 @@ describe(Repo.name, () => {
     });
   });
 
-  describe('itemTimestamps', () => {
+  describe('dateRanges', () => {
     beforeEach(() => {
       mockUploadFn.mockResolvedValue({
         error: null,
@@ -262,8 +270,18 @@ describe(Repo.name, () => {
         itemWithDate('3', '2021-03-01T00:00:00.000Z'),
       ]);
 
-      expect(repo.itemTimestamps.min).toBe(ts('2020-01-01T00:00:00.000Z'));
-      expect(repo.itemTimestamps.max).toBe(ts('2023-06-15T12:00:00.000Z'));
+      expect(repo.dateRanges.creationDate.oldest).toBe(
+        ts('2020-01-01T00:00:00.000Z')
+      );
+      expect(repo.dateRanges.creationDate.newest).toBe(
+        ts('2023-06-15T12:00:00.000Z')
+      );
+      expect(repo.dateRanges.modifiedDate.oldest).toBe(
+        ts('2020-01-01T00:00:00.000Z')
+      );
+      expect(repo.dateRanges.modifiedDate.newest).toBe(
+        ts('2023-06-15T12:00:00.000Z')
+      );
     });
 
     it('should skip items without created_date', async () => {
@@ -281,8 +299,12 @@ describe(Repo.name, () => {
         attachmentWithoutDate,
       ]);
 
-      expect(repo.itemTimestamps.min).toBe(ts('2022-06-01T00:00:00.000Z'));
-      expect(repo.itemTimestamps.max).toBe(ts('2022-06-01T00:00:00.000Z'));
+      expect(repo.dateRanges.creationDate.oldest).toBe(
+        ts('2022-06-01T00:00:00.000Z')
+      );
+      expect(repo.dateRanges.creationDate.newest).toBe(
+        ts('2022-06-01T00:00:00.000Z')
+      );
     });
 
     it('should leave timestamps at zero when no items have created_date', async () => {
@@ -296,13 +318,19 @@ describe(Repo.name, () => {
         },
       ]);
 
-      expect(repo.itemTimestamps).toEqual({ min: 0, max: 0 });
+      expect(repo.dateRanges).toEqual({
+        creationDate: { oldest: 0, newest: 0 },
+        modifiedDate: { oldest: 0, newest: 0 },
+      });
     });
 
     it('should not update timestamps or call uploader on empty upload', async () => {
       await repo.upload([]);
 
-      expect(repo.itemTimestamps).toEqual({ min: 0, max: 0 });
+      expect(repo.dateRanges).toEqual({
+        creationDate: { oldest: 0, newest: 0 },
+        modifiedDate: { oldest: 0, newest: 0 },
+      });
       expect(mockUploadFn).not.toHaveBeenCalled();
     });
 
@@ -332,8 +360,12 @@ describe(Repo.name, () => {
       await repo.push(items);
 
       expect(repo.getItems()).toHaveLength(1);
-      expect(repo.itemTimestamps.min).toBe(ts('2020-01-01T00:00:00.000Z'));
-      expect(repo.itemTimestamps.max).toBe(ts('2024-12-01T00:00:00.000Z'));
+      expect(repo.dateRanges.creationDate.oldest).toBe(
+        ts('2020-01-01T00:00:00.000Z')
+      );
+      expect(repo.dateRanges.creationDate.newest).toBe(
+        ts('2024-12-01T00:00:00.000Z')
+      );
 
       await repo.push([
         itemWithDate('7', '2019-01-01T00:00:00.000Z'),
@@ -341,8 +373,12 @@ describe(Repo.name, () => {
       ]);
 
       expect(repo.getItems()).toHaveLength(0);
-      expect(repo.itemTimestamps.min).toBe(ts('2019-01-01T00:00:00.000Z'));
-      expect(repo.itemTimestamps.max).toBe(ts('2025-01-01T00:00:00.000Z'));
+      expect(repo.dateRanges.creationDate.oldest).toBe(
+        ts('2019-01-01T00:00:00.000Z')
+      );
+      expect(repo.dateRanges.creationDate.newest).toBe(
+        ts('2025-01-01T00:00:00.000Z')
+      );
     });
 
     it('should extend min and max when subsequent batches have wider date range', async () => {
@@ -351,16 +387,24 @@ describe(Repo.name, () => {
         itemWithDate('2', '2023-06-01T00:00:00.000Z'),
       ]);
 
-      expect(repo.itemTimestamps.min).toBe(ts('2022-06-01T00:00:00.000Z'));
-      expect(repo.itemTimestamps.max).toBe(ts('2023-06-01T00:00:00.000Z'));
+      expect(repo.dateRanges.creationDate.oldest).toBe(
+        ts('2022-06-01T00:00:00.000Z')
+      );
+      expect(repo.dateRanges.creationDate.newest).toBe(
+        ts('2023-06-01T00:00:00.000Z')
+      );
 
       await repo.upload([
         itemWithDate('3', '2020-01-01T00:00:00.000Z'),
         itemWithDate('4', '2024-01-01T00:00:00.000Z'),
       ]);
 
-      expect(repo.itemTimestamps.min).toBe(ts('2020-01-01T00:00:00.000Z'));
-      expect(repo.itemTimestamps.max).toBe(ts('2024-01-01T00:00:00.000Z'));
+      expect(repo.dateRanges.creationDate.oldest).toBe(
+        ts('2020-01-01T00:00:00.000Z')
+      );
+      expect(repo.dateRanges.creationDate.newest).toBe(
+        ts('2024-01-01T00:00:00.000Z')
+      );
     });
 
     it('should update timestamps even when upload fails', async () => {
@@ -371,8 +415,32 @@ describe(Repo.name, () => {
 
       await repo.upload([itemWithDate('1', '2022-01-01T00:00:00.000Z')]);
 
-      expect(repo.itemTimestamps.min).toBe(ts('2022-01-01T00:00:00.000Z'));
-      expect(repo.itemTimestamps.max).toBe(ts('2022-01-01T00:00:00.000Z'));
+      expect(repo.dateRanges.creationDate.oldest).toBe(
+        ts('2022-01-01T00:00:00.000Z')
+      );
+      expect(repo.dateRanges.creationDate.newest).toBe(
+        ts('2022-01-01T00:00:00.000Z')
+      );
+    });
+
+    it('should track modified_date independently from created_date', async () => {
+      await repo.upload([
+        itemWithDates('1', '2020-01-01T00:00:00.000Z', '2023-01-01T00:00:00.000Z'),
+        itemWithDates('2', '2024-01-01T00:00:00.000Z', '2021-06-01T00:00:00.000Z'),
+      ]);
+
+      expect(repo.dateRanges.creationDate.oldest).toBe(
+        ts('2020-01-01T00:00:00.000Z')
+      );
+      expect(repo.dateRanges.creationDate.newest).toBe(
+        ts('2024-01-01T00:00:00.000Z')
+      );
+      expect(repo.dateRanges.modifiedDate.oldest).toBe(
+        ts('2021-06-01T00:00:00.000Z')
+      );
+      expect(repo.dateRanges.modifiedDate.newest).toBe(
+        ts('2023-01-01T00:00:00.000Z')
+      );
     });
   });
 });

--- a/src/repo/repo.ts
+++ b/src/repo/repo.ts
@@ -16,6 +16,18 @@ import {
   RepoFactoryInterface,
 } from './repo.interfaces';
 
+function updateRange(
+  range: { oldest: number; newest: number },
+  ms: number
+): void {
+  if (range.oldest === 0 || ms < range.oldest) {
+    range.oldest = ms;
+  }
+  if (range.newest === 0 || ms > range.newest) {
+    range.newest = ms;
+  }
+}
+
 export class Repo {
   readonly itemType: string;
   private items: (NormalizedItem | NormalizedAttachment | Item)[];
@@ -24,9 +36,9 @@ export class Repo {
   private onUpload: (artifact: Artifact) => void;
   private options?: WorkerAdapterOptions;
   public uploadedArtifacts: Artifact[];
-  public itemTimestamps: { min: number; max: number } = {
-    min: 0,
-    max: 0,
+  public dateRanges = {
+    creationDate: { oldest: 0, newest: 0 },
+    modifiedDate: { oldest: 0, newest: 0 },
   };
 
   constructor({
@@ -57,19 +69,16 @@ export class Repo {
     if (itemsToUpload.length > 0) {
       for (const item of itemsToUpload) {
         if (item?.created_date != null) {
-          const createdDate = new Date(item.created_date).getTime();
-          if (
-            this.itemTimestamps.min == 0 ||
-            createdDate < this.itemTimestamps.min
-          ) {
-            this.itemTimestamps.min = createdDate;
-          }
-          if (
-            this.itemTimestamps.max == 0 ||
-            createdDate > this.itemTimestamps.max
-          ) {
-            this.itemTimestamps.max = createdDate;
-          }
+          updateRange(
+            this.dateRanges.creationDate,
+            new Date(item.created_date).getTime()
+          );
+        }
+        if (item?.modified_date != null && item.modified_date !== '') {
+          updateRange(
+            this.dateRanges.modifiedDate,
+            new Date(item.modified_date).getTime()
+          );
         }
       }
 

--- a/src/repo/repo.ts
+++ b/src/repo/repo.ts
@@ -24,6 +24,10 @@ export class Repo {
   private onUpload: (artifact: Artifact) => void;
   private options?: WorkerAdapterOptions;
   public uploadedArtifacts: Artifact[];
+  public itemTimestamps: { min: number; max: number } = {
+    min: 0,
+    max: 0,
+  };
 
   constructor({
     event,
@@ -51,6 +55,28 @@ export class Repo {
     const itemsToUpload = batch || this.items;
 
     if (itemsToUpload.length > 0) {
+      for (const item of itemsToUpload) {
+        if (
+          item != null &&
+          'created_date' in item &&
+          item.created_date != null
+        ) {
+          const created_date = new Date(item['created_date']).getTime();
+          if (
+            this.itemTimestamps.min == 0 ||
+            created_date < this.itemTimestamps.min
+          ) {
+            this.itemTimestamps.min = created_date;
+          }
+          if (
+            this.itemTimestamps.max == 0 ||
+            created_date > this.itemTimestamps.max
+          ) {
+            this.itemTimestamps.max = created_date;
+          }
+        }
+      }
+
       console.log(
         `Uploading ${itemsToUpload.length} items of type ${this.itemType}. `
       );

--- a/src/repo/repo.ts
+++ b/src/repo/repo.ts
@@ -56,23 +56,19 @@ export class Repo {
 
     if (itemsToUpload.length > 0) {
       for (const item of itemsToUpload) {
-        if (
-          item != null &&
-          'created_date' in item &&
-          item.created_date != null
-        ) {
-          const created_date = new Date(item['created_date']).getTime();
+        if (item?.created_date != null) {
+          const createdDate = new Date(item.created_date).getTime();
           if (
             this.itemTimestamps.min == 0 ||
-            created_date < this.itemTimestamps.min
+            createdDate < this.itemTimestamps.min
           ) {
-            this.itemTimestamps.min = created_date;
+            this.itemTimestamps.min = createdDate;
           }
           if (
             this.itemTimestamps.max == 0 ||
-            created_date > this.itemTimestamps.max
+            createdDate > this.itemTimestamps.max
           ) {
-            this.itemTimestamps.max = created_date;
+            this.itemTimestamps.max = createdDate;
           }
         }
       }

--- a/src/repo/repo.ts
+++ b/src/repo/repo.ts
@@ -28,6 +28,11 @@ function updateRange(
   }
 }
 
+function toValidTimestamp(value: string): number | undefined {
+  const ms = new Date(value).getTime();
+  return Number.isFinite(ms) ? ms : undefined;
+}
+
 export class Repo {
   readonly itemType: string;
   private items: (NormalizedItem | NormalizedAttachment | Item)[];
@@ -68,17 +73,19 @@ export class Repo {
 
     if (itemsToUpload.length > 0) {
       for (const item of itemsToUpload) {
-        if (item?.created_date != null) {
-          updateRange(
-            this.dateRanges.creationDate,
-            new Date(item.created_date).getTime()
-          );
+        const createdDate = item?.created_date;
+        if (createdDate != null) {
+          const createdMs = toValidTimestamp(createdDate);
+          if (createdMs !== undefined) {
+            updateRange(this.dateRanges.creationDate, createdMs);
+          }
         }
-        if (item?.modified_date != null && item.modified_date !== '') {
-          updateRange(
-            this.dateRanges.modifiedDate,
-            new Date(item.modified_date).getTime()
-          );
+        const modifiedDate = item?.modified_date;
+        if (modifiedDate != null && modifiedDate !== '') {
+          const modifiedMs = toValidTimestamp(modifiedDate);
+          if (modifiedMs !== undefined) {
+            updateRange(this.dateRanges.modifiedDate, modifiedMs);
+          }
         }
       }
 

--- a/src/types/extraction.ts
+++ b/src/types/extraction.ts
@@ -3,8 +3,6 @@ import { InputData } from '@devrev/typescript-sdk/dist/snap-ins';
 import { Artifact } from '../uploader/uploader.interfaces';
 
 import { ErrorRecord } from './common';
-import type { ProgressData } from '../common/control-protocol';
-
 import { AxiosResponse } from 'axios';
 import { NormalizedAttachment } from '../repo/repo.interfaces';
 import { WorkerAdapter } from '../multithreading/worker-adapter/worker-adapter';
@@ -420,8 +418,18 @@ export interface EventData {
  * WorkerMetadata is an interface that defines the structure of the worker metadata that is sent from the external extractor to ADaaS.
  */
 export interface WorkerMetadata {
-  adaas_library_version: string;
-  progress_data?: ProgressData;
+  adaas_library_version?: string;
+
+  // Last extracted item type statistics
+  item_type?: string;
+  oldest_created_date?: string;
+  newest_created_date?: string;
+  oldest_modified_date?: string;
+  newest_modified_date?: string;
+
+  // Calculated time ranges in absolute times
+  oldest_state_date?: string;
+  newest_state_date?: string;
 }
 
 /**

--- a/src/types/extraction.ts
+++ b/src/types/extraction.ts
@@ -3,6 +3,7 @@ import { InputData } from '@devrev/typescript-sdk/dist/snap-ins';
 import { Artifact } from '../uploader/uploader.interfaces';
 
 import { ErrorRecord } from './common';
+import type { ProgressData } from '../common/control-protocol';
 
 import { AxiosResponse } from 'axios';
 import { NormalizedAttachment } from '../repo/repo.interfaces';
@@ -420,11 +421,7 @@ export interface EventData {
  */
 export interface WorkerMetadata {
   adaas_library_version: string;
-  progress_data?: {
-    item_type?: string;
-    creationDate?: { oldest: number; newest: number };
-    modifiedDate?: { oldest: number; newest: number };
-  };
+  progress_data?: ProgressData;
 }
 
 /**

--- a/src/types/extraction.ts
+++ b/src/types/extraction.ts
@@ -420,6 +420,11 @@ export interface EventData {
  */
 export interface WorkerMetadata {
   adaas_library_version: string;
+  progress_data?: {
+    item_type?: string;
+    creationDate?: { oldest: number; newest: number };
+    modifiedDate?: { oldest: number; newest: number };
+  };
 }
 
 /**


### PR DESCRIPTION
This PR flattens extraction progress metadata into `worker_metadata` and adds timestamp bounds the platform can use to detect incremental syncs that are not advancing.

- **`NormalizedAttachment.created_date`** and **`NormalizedAttachment.modified_date`** (optional): attachments can now contribute source timestamps the same way normalized items do.
- **`Repo.dateRanges`**: each repo now tracks the oldest/newest valid `created_date` and `modified_date` seen across uploaded batches.
- **Flat `worker_metadata` progress fields**: extraction progress/done events now send the latest extracted repo’s `item_type`, `oldest_created_date`, `newest_created_date`, `oldest_modified_date`, and `newest_modified_date`.
- **State window fields in `worker_metadata`**: `oldest_state_date` and `newest_state_date` are copied from `event_context.extract_from` / `extract_to` on emitted callback payloads.

## Connected Issues

- [#ISS-252036](https://app.devrev.ai/devrev/works/ISS-252036)

## Checklist

- [x] Tests added/updated and ran with `npm run test` OR no tests needed.
- [x] Ran backwards compatibility tests with `npm run test:backwards-compatibility`.
- [x] Code formatted and checked with `npm run lint`.
- [x] Tested `airdrop-template` linked to this PR.
- [x] Documentation updated and provided a link to PR / new docs OR no docs needed.

## Migration note

If your connector normalizes attachments, populate `created_date` and/or `modified_date` on each `NormalizedAttachment` using the source system timestamp in RFC3339 format.

```typescript
const normalizedAttachment: NormalizedAttachment = {
  id: attachment.id,
  url: attachment.downloadUrl,
  file_name: attachment.name,
  parent_id: attachment.parentId,
  created_date: attachment.createdAt,
  modified_date: attachment.updatedAt,
};
```

Notes:

- Attachment timestamp fields are optional, so existing connectors keep working.
- Attachment repos only contribute created/modified bounds when those fields are populated.
- Invalid timestamp strings are ignored and do not corrupt the tracked ranges.
- Normalized items already support `created_date` / `modified_date`; no connector-side change is needed there.

---

## What `worker_metadata` now contains

`worker_metadata` is part of the callback payload. It is not inside `event_data`.

### Repo progress fields

These fields are attached only for:

- `DATA_EXTRACTION_PROGRESS`
- `DATA_EXTRACTION_DONE`
- `ATTACHMENT_EXTRACTION_PROGRESS`
- `ATTACHMENT_EXTRACTION_DONE`

Shape:

```typescript
worker_metadata: {
  item_type?: string;
  oldest_created_date?: string;
  newest_created_date?: string;
  oldest_modified_date?: string;
  newest_modified_date?: string;
  oldest_state_date?: string;
  newest_state_date?: string;
  adaas_library_version?: string;
}
```

Behavior:

- The repo progress fields describe only the **latest extracted repo**.
- Values are emitted as **RFC3339 strings**.
- Unset bounds are omitted.
- Loader events and non-progress extraction events do not include repo progress fields.

Example:

```json
{
  "worker_metadata": {
    "item_type": "issues",
    "oldest_created_date": "2024-01-01T00:00:00.000Z",
    "newest_created_date": "2024-05-01T00:00:00.000Z",
    "oldest_modified_date": "2024-02-01T00:00:00.000Z",
    "newest_modified_date": "2024-06-01T00:00:00.000Z",
    "oldest_state_date": "2024-01-01T00:00:00.000Z",
    "newest_state_date": "2024-06-01T00:00:00.000Z",
    "adaas_library_version": "..."
  }
}
```

### How repo progress fields are computed

1. On each `Repo.upload()`, the SDK scans uploaded items for valid `created_date` and `modified_date` values.
2. It updates that repo’s running `dateRanges.creationDate` and `dateRanges.modifiedDate`.
3. On the extraction progress/done events above, `WorkerAdapter` emits the bounds for the repo identified by the latest uploaded `itemType`.

### How state window fields are computed

- `oldest_state_date` is copied from `event_context.extract_from`.
- `newest_state_date` is copied from `event_context.extract_to`.
- These values are injected by `control-protocol.emit()` and override caller-provided state-date values.

### Why this exists

The platform can compare the emitted repo timestamp bounds together with the absolute extraction window. If repeated runs keep reporting the same latest-item bounds and state window, that is a signal that the incremental sync is not making forward progress.
