### PR TITLE
fix: gracefully handle soft timeout messages while streaming attachments

### DIFF
--- a/src/attachments-streaming/attachments-streaming-pool.test.ts
+++ b/src/attachments-streaming/attachments-streaming-pool.test.ts
@@ -28,6 +28,10 @@ describe(AttachmentsStreamingPool.name, () => {
           },
         },
       },
+      isTimeout: false,
+      // Never resolves: streamAll's race is decided by the workers completing,
+      // unless a test overrides this / flips isTimeout.
+      timeoutSignal: new Promise<void>(() => {}),
       processAttachment: jest
         .fn()
         .mockResolvedValue({} as ProcessAttachmentReturnType),
@@ -682,6 +686,87 @@ describe(AttachmentsStreamingPool.name, () => {
       // Verify the user callback was executed
       expect(userCallbackExecuted).toBe(true);
       expect(mockStreamFn).toHaveBeenCalled();
+    });
+  });
+
+  describe('soft timeout handling', () => {
+    it('should resolve streamAll when the timeout signal fires even if a worker is stuck in flight', async () => {
+      // A worker stuck in a never-resolving request: only the timeout race can
+      // unblock streamAll.
+      mockAdapter.processAttachment.mockImplementation(
+        async () => new Promise<ProcessAttachmentReturnType>(() => {})
+      );
+
+      let fireTimeout!: () => void;
+      (mockAdapter as any).timeoutSignal = new Promise<void>((resolve) => {
+        fireTimeout = resolve;
+      });
+
+      const pool = new AttachmentsStreamingPool({
+        adapter: mockAdapter,
+        attachments: mockAttachments,
+        batchSize: 10,
+        stream: mockStream,
+      });
+
+      const streamAllPromise = pool.streamAll();
+
+      (mockAdapter as any).isTimeout = true;
+      fireTimeout();
+
+      const result = await streamAllPromise;
+      expect(result).toEqual({});
+    });
+
+    it('should not record an attachment as processed when a timeout fires while it is in flight', async () => {
+      mockAdapter.processAttachment.mockImplementation(async () => {
+        await Promise.resolve();
+        (mockAdapter as any).isTimeout = true;
+        return {};
+      });
+
+      const pool = new AttachmentsStreamingPool({
+        adapter: mockAdapter,
+        attachments: mockAttachments,
+        batchSize: 1,
+        stream: mockStream,
+      });
+
+      await pool.streamAll();
+
+      expect(
+        mockAdapter.state.toDevRev!.attachmentsMetadata
+          .lastProcessedAttachmentsIdsList
+      ).toEqual([]);
+      expect(mockAdapter.processAttachment).toHaveBeenCalledTimes(1);
+    });
+
+    it('should record attachments completed before the timeout and stop after', async () => {
+      let calls = 0;
+      mockAdapter.processAttachment.mockImplementation(async () => {
+        await Promise.resolve();
+        calls++;
+        if (calls === 2) {
+          (mockAdapter as any).isTimeout = true;
+        }
+        return {};
+      });
+
+      const pool = new AttachmentsStreamingPool({
+        adapter: mockAdapter,
+        attachments: mockAttachments,
+        batchSize: 1,
+        stream: mockStream,
+      });
+
+      await pool.streamAll();
+
+      expect(
+        mockAdapter.state.toDevRev!.attachmentsMetadata
+          .lastProcessedAttachmentsIdsList
+      ).toEqual([{ id: 'attachment-1', parent_id: 'parent-1' }]);
+      // 2nd was started then abandoned; 3rd never started.
+      expect(mockAdapter.processAttachment).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/src/attachments-streaming/attachments-streaming-pool.ts
+++ b/src/attachments-streaming/attachments-streaming-pool.ts
@@ -105,8 +105,10 @@ export class AttachmentsStreamingPool<ConnectorState> {
       initialPromises.push(this.startPoolStreaming());
     }
 
-    // Wait for all promises to complete
-    await Promise.all(initialPromises);
+    await Promise.race([
+      Promise.all(initialPromises),
+      this.adapter.timeoutSignal,
+    ]);
 
     if (this.delay) {
       return { delay: this.delay };
@@ -178,8 +180,8 @@ export class AttachmentsStreamingPool<ConnectorState> {
           continue;
         }
 
-        // No rate limiting, process normally
         if (
+          !this.adapter.isTimeout &&
           this.adapter.state.toDevRev?.attachmentsMetadata
             ?.lastProcessedAttachmentsIdsList
         ) {

--- a/src/mock-server/mock-server.interfaces.ts
+++ b/src/mock-server/mock-server.interfaces.ts
@@ -16,6 +16,8 @@ export interface MockResponse extends ServerResponse {
   status(code: number): MockResponse;
   /** Send a JSON response */
   json(data: unknown): void;
+  /** Send a raw binary (Buffer) response */
+  buffer(data: Buffer): void;
   /** Send an empty response */
   send(): void;
 }
@@ -48,6 +50,8 @@ export interface RouteConfig {
   status: number;
   /** Optional response body to send as JSON */
   body?: unknown;
+  /** Optional raw binary response body, e.g. gzipped JSONL (takes precedence over `body`) */
+  bodyBuffer?: Buffer;
   /** Optional headers to send with the response */
   headers?: Record<string, string>;
   /** Optional retry configuration for simulating failures before success */

--- a/src/mock-server/mock-server.ts
+++ b/src/mock-server/mock-server.ts
@@ -71,6 +71,11 @@ function wrapResponse(res: ServerResponse): MockResponse {
     res.end(JSON.stringify(data));
   };
 
+  mock.buffer = (data: Buffer) => {
+    res.writeHead(statusCode, { 'Content-Type': 'application/octet-stream' });
+    res.end(data);
+  };
+
   mock.send = () => {
     res.writeHead(statusCode);
     res.end();
@@ -211,7 +216,8 @@ export class MockServer {
    * Configures a route to return a specific status code and optional response body.
    */
   public setRoute(config: RouteConfig): void {
-    const { path, method, status, body, retry, headers, delay } = config;
+    const { path, method, status, body, bodyBuffer, retry, headers, delay } =
+      config;
     const key = this.getRouteKey(method, path);
 
     if (retry) {
@@ -253,7 +259,9 @@ export class MockServer {
                 res.set(headers);
               }
 
-              if (body !== undefined) {
+              if (bodyBuffer !== undefined) {
+                res.status(status).buffer(bodyBuffer);
+              } else if (body !== undefined) {
                 res.status(status).json(body);
               } else {
                 this.defaultRouteHandler(req, res);
@@ -264,7 +272,9 @@ export class MockServer {
               res.set(headers);
             }
 
-            if (body !== undefined) {
+            if (bodyBuffer !== undefined) {
+              res.status(status).buffer(bodyBuffer);
+            } else if (body !== undefined) {
               res.status(status).json(body);
             } else {
               res.status(status).send();

--- a/src/multithreading/worker-adapter/worker-adapter.ts
+++ b/src/multithreading/worker-adapter/worker-adapter.ts
@@ -91,8 +91,13 @@ export function createWorkerAdapter<ConnectorState>({
 export class WorkerAdapter<ConnectorState> {
   readonly event: AirdropEvent;
   readonly options?: WorkerAdapterOptions;
-  isTimeout: boolean;
   hasWorkerEmitted: boolean;
+
+  private _isTimeout: boolean = false;
+  private resolveTimeoutSignal!: () => void;
+  readonly timeoutSignal: Promise<void> = new Promise<void>((resolve) => {
+    this.resolveTimeoutSignal = resolve;
+  });
 
   private adapterState: State<ConnectorState>;
   private _artifacts: Artifact[];
@@ -115,7 +120,6 @@ export class WorkerAdapter<ConnectorState> {
     this.adapterState = adapterState;
     this._artifacts = [];
     this.hasWorkerEmitted = false;
-    this.isTimeout = false;
 
     // Loader
     this.loaderReports = [];
@@ -128,6 +132,17 @@ export class WorkerAdapter<ConnectorState> {
       event,
       options,
     });
+  }
+
+  get isTimeout(): boolean {
+    return this._isTimeout;
+  }
+
+  set isTimeout(value: boolean) {
+    this._isTimeout = value;
+    if (value) {
+      this.resolveTimeoutSignal();
+    }
   }
 
   get state(): AdapterState<ConnectorState> {
@@ -992,6 +1007,11 @@ export class WorkerAdapter<ConnectorState> {
           ssorAttachment.inline = true;
         } else if (attachment.inline === false) {
           ssorAttachment.inline = false;
+        }
+
+        if (this.isTimeout) {
+          this.destroyHttpStream(httpStream);
+          return;
         }
 
         await this.getRepo('ssor_attachment')?.push([ssorAttachment]);

--- a/src/tests/timeout-handling/attachments-extraction.ts
+++ b/src/tests/timeout-handling/attachments-extraction.ts
@@ -1,0 +1,26 @@
+import { AirdropEvent, spawn } from '../../index';
+
+interface ExtractorState {
+  [key: string]: unknown;
+}
+
+const initialState = {};
+const initialDomainMapping = {};
+
+const run = async (events: AirdropEvent[], workerPath: string) => {
+  for (const event of events) {
+    await spawn<ExtractorState>({
+      event,
+      initialState,
+      workerPath,
+      initialDomainMapping,
+      options: {
+        batchSize: 1000,
+        timeout: 4 * 1000, // 4s soft timeout -> ~5.2s hard timeout
+        isLocalDevelopment: true,
+      },
+    });
+  }
+};
+
+export default run;

--- a/src/tests/timeout-handling/attachments-timeout-hung-stream.ts
+++ b/src/tests/timeout-handling/attachments-timeout-hung-stream.ts
@@ -1,0 +1,38 @@
+import { AxiosResponse } from 'axios';
+import { Readable } from 'stream';
+
+import { ExtractorEventType, processTask } from '../../index';
+import {
+  ExternalSystemAttachmentStreamingResponse,
+  ExternalSystemAttachmentStreamingParams,
+} from '../../types/extraction';
+
+// Repro for logs2.csv: one attachment's stream() hangs forever, keeping a pool
+// worker (and streamAll) pending past the soft timeout.
+processTask({
+  task: async ({ adapter }) => {
+    await adapter.streamAttachments({
+      stream: async ({
+        item,
+      }: ExternalSystemAttachmentStreamingParams): Promise<ExternalSystemAttachmentStreamingResponse> => {
+        if (item.id === 'att-hangs') {
+          await new Promise<void>(() => {});
+        }
+
+        const data = Readable.from([Buffer.from('hello world')]);
+        return {
+          httpStream: {
+            data,
+            headers: { 'content-type': 'text/plain', 'content-length': '11' },
+          } as unknown as AxiosResponse,
+        };
+      },
+      batchSize: 10,
+    });
+
+    await adapter.emit(ExtractorEventType.AttachmentExtractionDone);
+  },
+  onTimeout: async ({ adapter }) => {
+    await adapter.emit(ExtractorEventType.AttachmentExtractionProgress);
+  },
+});

--- a/src/tests/timeout-handling/attachments-timeout-retry-storm.ts
+++ b/src/tests/timeout-handling/attachments-timeout-retry-storm.ts
@@ -1,0 +1,35 @@
+import { AxiosResponse } from 'axios';
+import { Readable } from 'stream';
+
+import { ExtractorEventType, processTask } from '../../index';
+import { ExternalSystemAttachmentStreamingResponse } from '../../types/extraction';
+
+// Repro for logs1.csv: stream() succeeds but the upload 5xxs, so axios-retry
+// backs off (2s, 4s, ...) and a pool worker is stuck mid-retry across the soft
+// timeout (it only re-checks the flag between attachments, never mid-retry).
+processTask({
+  task: async ({ adapter }) => {
+    await adapter.streamAttachments({
+      stream: async (): Promise<ExternalSystemAttachmentStreamingResponse> => {
+        await Promise.resolve();
+        const body = Buffer.from('hello world');
+        const data = Readable.from([body]);
+        return {
+          httpStream: {
+            data,
+            headers: {
+              'content-type': 'text/plain',
+              'content-length': String(body.length),
+            },
+          } as unknown as AxiosResponse,
+        };
+      },
+      batchSize: 10,
+    });
+
+    await adapter.emit(ExtractorEventType.AttachmentExtractionDone);
+  },
+  onTimeout: async ({ adapter }) => {
+    await adapter.emit(ExtractorEventType.AttachmentExtractionProgress);
+  },
+});

--- a/src/tests/timeout-handling/attachments-timeout.test.ts
+++ b/src/tests/timeout-handling/attachments-timeout.test.ts
@@ -1,0 +1,136 @@
+import zlib from 'zlib';
+import { jsonl } from 'js-jsonl';
+
+import {
+  AirdropEvent,
+  EventType,
+  ExtractorEvent,
+  ExtractorEventType,
+} from '../../types/extraction';
+import { NormalizedAttachment } from '../../repo/repo.interfaces';
+import { mockServer } from '../jest.setup';
+import { createMockEvent } from '../../common/test-utils';
+
+import run from './attachments-extraction';
+
+// Worker has a 4s soft / ~5.2s hard timeout. Allow generous headroom so the
+// test itself never times out before the worker resolves either way.
+jest.setTimeout(30000);
+
+const METADATA_ARTIFACT_ID = 'metadata-artifact-1';
+const METADATA_DOWNLOAD_PATH = '/download/metadata-artifact-1';
+
+function buildAttachments(
+  count: number,
+  hangId?: string
+): NormalizedAttachment[] {
+  const attachments: NormalizedAttachment[] = [];
+  for (let i = 0; i < count; i++) {
+    attachments.push({
+      url: `https://example.com/file-${i}.txt`,
+      id: `att-${i}`,
+      file_name: `file-${i}.txt`,
+      parent_id: `parent-${i}`,
+    });
+  }
+  if (hangId) {
+    // Land the hung attachment in the first concurrent batch (batchSize 10).
+    attachments[9] = {
+      url: 'https://example.com/hang.txt',
+      id: hangId,
+      file_name: 'hang.txt',
+      parent_id: 'parent-hang',
+    };
+  }
+  return attachments;
+}
+
+function seedAttachmentsState(
+  baseUrl: string,
+  attachments: NormalizedAttachment[]
+): void {
+  const state = {
+    lastSyncStarted: '',
+    lastSuccessfulSyncStarted: '',
+    pendingWorkersOldest: '',
+    pendingWorkersNewest: '',
+    workersOldest: '',
+    workersNewest: '',
+    snapInVersionId: 'test_snap_in_version_id',
+    toDevRev: {
+      attachmentsMetadata: {
+        artifactIds: [METADATA_ARTIFACT_ID],
+        lastProcessed: 0,
+        lastProcessedAttachmentsIdsList: [],
+      },
+    },
+  };
+
+  mockServer.setRoute({
+    path: '/worker_data_url.get',
+    method: 'GET',
+    status: 200,
+    body: { state: JSON.stringify(state) },
+  });
+
+  mockServer.setRoute({
+    path: '/internal/airdrop.artifacts.download-url',
+    method: 'GET',
+    status: 200,
+    body: { download_url: `${baseUrl}${METADATA_DOWNLOAD_PATH}` },
+  });
+
+  // The metadata artifact is downloaded as an arraybuffer of gzipped JSONL.
+  const gzipped = zlib.gzipSync(jsonl.stringify(attachments));
+  mockServer.setRoute({
+    path: METADATA_DOWNLOAD_PATH,
+    method: 'GET',
+    status: 200,
+    bodyBuffer: gzipped,
+  });
+}
+
+describe('Attachments streaming soft timeout', () => {
+  let event: AirdropEvent;
+
+  beforeEach(() => {
+    event = createMockEvent(mockServer.baseUrl, {
+      payload: { event_type: EventType.StartExtractingAttachments },
+    });
+  });
+
+  it('emits PROGRESS (not hard-timeout ERROR) when a stream() call hangs past the soft timeout (logs2)', async () => {
+    const attachments = buildAttachments(30, 'att-hangs');
+    seedAttachmentsState(mockServer.baseUrl, attachments);
+
+    await run([event], __dirname + '/attachments-timeout-hung-stream');
+
+    const lastRequest = mockServer.getLastRequest();
+    expect(lastRequest?.url).toContain('/callback_url');
+    expect(lastRequest?.method).toBe('POST');
+    expect((lastRequest?.body as ExtractorEvent).event_type).toBe(
+      ExtractorEventType.AttachmentExtractionProgress
+    );
+  });
+
+  it('emits PROGRESS (not hard-timeout ERROR) when artifact uploads 5xx into a retry storm past the soft timeout (logs1)', async () => {
+    const attachments = buildAttachments(30);
+    seedAttachmentsState(mockServer.baseUrl, attachments);
+
+    // Upload always 500s -> axios-retry backoff keeps a worker stuck mid-retry.
+    mockServer.setRoute({
+      path: '/file-upload-url',
+      method: 'POST',
+      status: 500,
+    });
+
+    await run([event], __dirname + '/attachments-timeout-retry-storm');
+
+    const lastRequest = mockServer.getLastRequest();
+    expect(lastRequest?.url).toContain('/callback_url');
+    expect(lastRequest?.method).toBe('POST');
+    expect((lastRequest?.body as ExtractorEvent).event_type).toBe(
+      ExtractorEventType.AttachmentExtractionProgress
+    );
+  });
+});


### PR DESCRIPTION
## Description

<!--
    A brief description of what the PR does/changes.
    Use active voice and present tense, e.g., This PR fixes ...
-->
This PR fixes that streamAll function now races Promise.all against timeout signal and as soon as the soft timeout happens it emits the progress event and exits gracefully, not waiting for batch of 10 attachments to finish.

## Connected Issues
<!--
    DevRev issue(s) full link(s) (e.g. https://app.devrev.ai/devrev/works/ISS-123).
-->
https://app.devrev.ai/devrev/issue/ASCPT-34

## Checklist

- [x] Tests added/updated and ran with `npm run test` OR no tests needed.
- [x] Ran backwards compatibility tests with `npm run test:backwards-compatibility`.
- [x] Code formatted and checked with `npm run lint`.
- [x] Tested airdrop-template linked to this PR.
- [x] Documentation updated and provided a link to PR / new docs OR no docs needed.
