### PR TITLE
feat: Add pre_extraction_item_counts to EventData for sync duration estimation

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -466,6 +466,37 @@ Defines the structure of event data that is sent from the external extractor to 
 
   Optional. A **string** representing the stats file artifact ID.
 
+- _pre_extraction_item_counts_
+
+  Optional. An array of **ItemTypeCount** objects reporting per-record-type counts collected during the metadata phase. Used for sync duration estimation.
+
+### `ItemInputType` enum
+
+Defines which sync duration estimation input a counted record type feeds into.
+
+#### Values
+
+- `MAIN` = `'main'`
+- `USERS` = `'users'`
+
+### `ItemTypeCount` interface
+
+Represents a per-record-type count reported during the metadata phase, used for sync duration estimation.
+
+#### Properties
+
+- _record_type_
+
+  Required. A **string** identifying the external record type being counted.
+
+- _count_
+
+  Required. A **number** with the count of records of this type.
+
+- _model_input_type_
+
+  Required. An **ItemInputType** value indicating which estimation input this record type feeds into.
+
 ### `EventType` enum
 
 Defines the different types of events that can be sent to the external extractor from ADaaS. The external extractor uses these events to know what to do next in the extraction process.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@devrev/ts-adaas",
-  "version": "1.20.1",
+  "version": "1.20.2-beta.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@devrev/ts-adaas",
-      "version": "1.20.1",
+      "version": "1.20.2-beta.0",
       "license": "ISC",
       "dependencies": {
         "@devrev/typescript-sdk": "^1.1.78",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@devrev/ts-adaas",
-  "version": "1.20.1",
+  "version": "1.20.2-beta.0",
   "description": "Typescript library containing the ADaaS(AirDrop as a Service) control protocol.",
   "type": "commonjs",
   "main": "./dist/index.js",

--- a/src/multithreading/worker-adapter/worker-adapter.emit.test.ts
+++ b/src/multithreading/worker-adapter/worker-adapter.emit.test.ts
@@ -8,6 +8,7 @@ import {
   Artifact,
   EventType,
   ExtractorEventType,
+  ItemInputType,
   LoaderEventType,
 } from '../../types';
 import { ActionType, LoaderReport } from '../../types/loading';
@@ -238,6 +239,36 @@ describe(`${WorkerAdapter.name}.emit`, () => {
     expect(callData).not.toHaveProperty('artifacts');
     expect(callData).not.toHaveProperty('reports');
     expect(callData).not.toHaveProperty('processed_files');
+  });
+
+  it('should include pre_extraction_item_counts passed on the metadata-done event', async () => {
+    // Arrange
+    const { emit: mockEmit } = require('../../common/control-protocol');
+    adapter['adapterState'].postState = jest.fn().mockResolvedValue(undefined);
+    adapter.uploadAllRepos = jest.fn().mockResolvedValue(undefined);
+
+    // Act
+    await adapter.emit(ExtractorEventType.MetadataExtractionDone, {
+      pre_extraction_item_counts: [
+        {
+          record_type: 'tickets',
+          count: 0,
+          model_input_type: ItemInputType.MAIN,
+        },
+        {
+          record_type: 'customers',
+          count: 1200,
+          model_input_type: ItemInputType.USERS,
+        },
+      ],
+    });
+
+    // Assert
+    const callData = mockEmit.mock.calls[0][0].data;
+    expect(callData.pre_extraction_item_counts).toEqual([
+      { record_type: 'tickets', count: 0, model_input_type: 'main' },
+      { record_type: 'customers', count: 1200, model_input_type: 'users' },
+    ]);
   });
 
   it('should include artifacts for all ExtractorEventType values', async () => {

--- a/src/types/extraction.ts
+++ b/src/types/extraction.ts
@@ -388,6 +388,23 @@ export interface ConnectionData {
 }
 
 /**
+ * ItemInputType is the sync-duration-estimation model input a counted record type feeds into.
+ */
+export enum ItemInputType {
+  MAIN = 'main',
+  USERS = 'users',
+}
+
+/**
+ * ItemTypeCount is a per-record-type count reported during the metadata phase, used for sync-duration estimation.
+ */
+export interface ItemTypeCount {
+  record_type: string;
+  count: number;
+  model_input_type: ItemInputType;
+}
+
+/**
  * EventData is an interface that defines the structure of the event data that is sent from the external extractor to ADaaS.
  */
 export interface EventData {
@@ -412,6 +429,8 @@ export interface EventData {
   reports?: LoaderReport[];
   processed_files?: string[];
   stats_file?: string;
+  // Optional per-record-type counts reported on the metadata-done event, used for sync-duration estimation.
+  pre_extraction_item_counts?: ItemTypeCount[];
 }
 
 /**

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -30,6 +30,8 @@ export {
   ExtractorEvent,
   ExtractorEventType,
   InitialSyncScope,
+  ItemInputType,
+  ItemTypeCount,
   ProcessAttachmentReturnType,
   TimeUnit,
   TimeValue,


### PR DESCRIPTION
## Description

 Adds an optional `pre_extraction_item_counts` field to `EventData` so ADaaS snap-ins can report per-record-type counts on the `MetadataExtractionDone` event. Adds the `ItemTypeCount` interface and `ItemInputType` enum (`main` or `users`) and exports both. The field is optional, so existing snap-ins are unaffected.

Design doc: [ADaaS estimated duration extension](https://docs.google.com/document/d/1_VdhHQEyOWyT8qISVMYSwv48ZKS87QzQmqVVxoCLZ_o/edit?tab=t.0)

 ## Connected Issues
 [ASFND-360](https://app.devrev.ai/devrev/issue/ASFND-360)

 ## Checklist
- [x] Tests added/updated and ran with `npm run test` OR no tests needed.
- [x] Ran backwards compatibility tests with `npm run test:backwards-compatibility`.
- [x] Code formatted and checked with `npm run lint`.
- [x] Tested airdrop-template linked to this PR.
- [x] Documentation updated and provided a link to PR / new docs OR no docs needed.