### PR TITLE
fix: use plural 'attachments' item_type in attachment loader report

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@devrev/ts-adaas",
-  "version": "1.19.11-beta.0",
+  "version": "1.19.11-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@devrev/ts-adaas",
-      "version": "1.19.11-beta.0",
+      "version": "1.19.11-beta.1",
       "license": "ISC",
       "dependencies": {
         "@devrev/typescript-sdk": "^1.1.78",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@devrev/ts-adaas",
-  "version": "1.19.11-beta.0",
+  "version": "1.19.11-beta.1",
   "description": "Typescript library containing the ADaaS(AirDrop as a Service) control protocol.",
   "type": "commonjs",
   "main": "./dist/index.js",

--- a/src/multithreading/worker-adapter/worker-adapter.loading.test.ts
+++ b/src/multithreading/worker-adapter/worker-adapter.loading.test.ts
@@ -678,7 +678,7 @@ describe(`${WorkerAdapter.name}.loadAttachment`, () => {
     });
 
     // Assert
-    expect(result.report?.item_type).toBe('attachment');
+    expect(result.report?.item_type).toBe('attachments');
     expect(result.report?.[ActionType.CREATED]).toBe(1);
   });
 
@@ -724,6 +724,7 @@ describe(`${WorkerAdapter.name}.loadAttachment`, () => {
     });
 
     // Assert
+    expect(result.report?.item_type).toBe('attachments');
     expect(result.report?.[ActionType.FAILED]).toBe(1);
   });
 });

--- a/src/multithreading/worker-adapter/worker-adapter.ts
+++ b/src/multithreading/worker-adapter/worker-adapter.ts
@@ -1123,7 +1123,7 @@ export class WorkerAdapter<ConnectorState> {
 
         return {
           report: {
-            item_type: 'attachment',
+            item_type: 'attachments',
             [ActionType.CREATED]: 1,
           },
         };
@@ -1131,7 +1131,7 @@ export class WorkerAdapter<ConnectorState> {
         console.warn('Failed to create attachment in external system', error);
         return {
           report: {
-            item_type: 'attachment',
+            item_type: 'attachments',
             [ActionType.FAILED]: 1,
           },
         };


### PR DESCRIPTION
## Description

This PR fixes `WorkerAdapter.loadAttachment`, which emitted its `LoaderReport` with the singular `item_type: 'attachment'` (CREATED and FAILED branches) while the rest of the SDK and platform use the plural `'attachments'`. This broke destination-side report-count verification for reverse-synced attachments — the report said `attachment: N` but the verifier looked up `attachments`, found 0, and failed with `invalid_report_created_count` even though the attachments were created.

Both report branches now emit `'attachments'`; the co-located test assertions are updated. `supportedItemTypes: ['attachment']` is intentionally left singular — it is the stats-file batch-routing key, a separate channel from the report. Needs a forward-port to v2 (`loading-adapter.ts`).

## Connected Issues

https://app.devrev.ai/devrev/works/ISS-349228

## Checklist

- [x] Tests added/updated and ran with `npm run test` OR no tests needed.
- [x] Ran backwards compatibility tests with `npm run test:backwards-compatibility`.
- [x] Code formatted and checked with `npm run lint`.
- [x] Tested airdrop-template linked to this PR.
- [x] Documentation updated and provided a link to PR / new docs OR no docs needed.
