### PR TITLE
fix: bump fast-uri to 3.1.4 to patch SNYK-JS-FASTURI-18021349

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3176,9 +3176,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
-      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Description

This PR patches a high-severity Snyk finding in the transitive dev dependency `fast-uri`.

It bumps `fast-uri` **3.1.3 → 3.1.4** as a lockfile-only change (dev dependency, pulled in via `ajv > fast-uri` under the `@microsoft/api-extractor` toolchain), fixing the Interpretation Conflict vulnerability **SNYK-JS-FASTURI-18021349**. The bump is reachable within the parent `ajv`'s `^3.0.1` range, so no `package.json` change is needed. Resolved against `registry.npmjs.org` (the internal mirror lagged on `3.1.4`); no internal-mirror URLs remain in the lockfile. Verified with a clean `npm ci`, `npm run build`, `npm test`, and a re-run of `snyk test` (`SNYK-JS-FASTURI-18021349` no longer present).

**Remaining dev-only findings with no clean fix** (tracked separately, not addressed here):
- **SNYK-JS-INFLIGHT-6095116** — `inflight@1.0.6` (ISS-349246): abandoned package, no patched release; pulled in transitively via `jest > glob@7`. Would need an `overrides` entry or an upstream jest/glob upgrade — larger than a vuln-patch warrants.
- **SNYK-JS-JSYAML-17342520** — `js-yaml@3.15.0` (ISS-349247): fix only in `4.2.0`, unreachable because the parent `@istanbuljs/load-nyc-config@1.1.0` pins `js-yaml@^3.13.1` (cross-major).

Both are dev/test tooling only and are not shipped in the published package.

> Note: `npm run lint` currently reports 10 pre-existing prettier errors in `src/uploader/uploader.helpers.test.ts` — these are present on clean `main` and unrelated to this lockfile-only change, so they are not touched here.

## Connected Issues

- https://app.devrev.ai/devrev/works/ISS-349249 (fixed here — fast-uri)
- https://app.devrev.ai/devrev/works/ISS-349246 (tracked, no clean fix — inflight)
- https://app.devrev.ai/devrev/works/ISS-349247 (tracked, no clean fix — js-yaml)

## Checklist

- [ ] Tests added/updated and ran with `npm run test` OR no tests needed.
- [ ] Ran backwards compatibility tests with `npm run test:backwards-compatibility`.
- [ ] Code formatted and checked with `npm run lint`.
- [ ] Tested airdrop-template linked to this PR.
- [ ] Documentation updated and provided a link to PR / new docs OR no docs needed.
